### PR TITLE
Upgrade parsita

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -6,7 +6,7 @@ jobs:
   tox:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: [ubuntu-22.04, macos-12]
     runs-on: ${{ matrix.os }}
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cffi >= 1.11.0
-parsita >= 1.2.0
+parsita == 1.8.0b2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cffi >= 1.11.0
-parsita == 1.8.0b2
+parsita >= 2.0.0b1

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,10 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     cmdclass={

--- a/src/tensora/expression/parser.py
+++ b/src/tensora/expression/parser.py
@@ -2,7 +2,7 @@ __all__ = ['parse_assignment']
 
 from functools import reduce
 
-from parsita import TextParsers, lit, reg, rep, rep1sep, Result
+from parsita import ParserContext, lit, reg, rep, rep1sep, Result
 from parsita.util import splat
 
 from .ast import Assignment, Add, Subtract, Multiply, Tensor, Scalar, Integer, Float
@@ -18,7 +18,7 @@ def make_expression(first, rest):
     return value
 
 
-class TensorExpressionParsers(TextParsers):
+class TensorExpressionParsers(ParserContext, whitespace=r'[ ]*'):
     name = reg(r'[A-Za-z][A-Za-z0-9]*')
 
     # taco does not support negatives or exponents

--- a/src/tensora/format/parser.py
+++ b/src/tensora/format/parser.py
@@ -1,6 +1,6 @@
 __all__ = ['parse_format']
 
-from parsita import ParserContext, reg, lit, rep, eof, Result, Success, Failure, ParseError
+from parsita import ParserContext, reg, lit, rep, eof, Result, Success, Failure, ParseError, StringReader
 from parsita.util import constant
 
 from .format import Mode, Format
@@ -35,7 +35,9 @@ def parse_format(format: str) -> Result[Format]:
     elif isinstance(parse_result, Success):
         parse_value = parse_result.unwrap()
         if set(range(parse_value.order)) != set(parse_value.ordering):
-            return Failure(ParseError(f'Format ordering must be some order of the set {set(range(parse_value.order))} '
-                                      f'not {parse_value.ordering}'))
+            return Failure(ParseError(
+                    StringReader(format),
+                    f'format ordering as some order of the set {set(range(parse_value.order))}'
+                ))
         else:
             return parse_result

--- a/src/tensora/format/parser.py
+++ b/src/tensora/format/parser.py
@@ -1,6 +1,6 @@
 __all__ = ['parse_format']
 
-from parsita import TextParsers, reg, lit, rep, eof, Result, Success, Failure
+from parsita import ParserContext, reg, lit, rep, eof, Result, Success, Failure, ParseError
 from parsita.util import constant
 
 from .format import Mode, Format
@@ -15,7 +15,7 @@ def make_format_with_orderings(dims):
     return Format(tuple(modes), tuple(orderings))
 
 
-class FormatTextParsers(TextParsers, whitespace=None):
+class FormatTextParsers(ParserContext):
     integer = reg(r'[0-9]+') > int
     dense = lit('d') > constant(Mode.dense)
     compressed = lit('s') > constant(Mode.compressed)
@@ -33,9 +33,9 @@ def parse_format(format: str) -> Result[Format]:
     if isinstance(parse_result, Failure):
         return parse_result
     elif isinstance(parse_result, Success):
-        parse_value = parse_result.value
+        parse_value = parse_result.unwrap()
         if set(range(parse_value.order)) != set(parse_value.ordering):
-            return Failure(f'Format ordering must be some order of the set {set(range(parse_value.order))} not '
-                           f'{parse_value.ordering}')
+            return Failure(ParseError(f'Format ordering must be some order of the set {set(range(parse_value.order))} '
+                                      f'not {parse_value.ordering}'))
         else:
             return parse_result

--- a/src/tensora/format/parser.py
+++ b/src/tensora/format/parser.py
@@ -36,8 +36,8 @@ def parse_format(format: str) -> Result[Format]:
         parse_value = parse_result.unwrap()
         if set(range(parse_value.order)) != set(parse_value.ordering):
             return Failure(ParseError(
-                    StringReader(format),
-                    f'format ordering as some order of the set {set(range(parse_value.order))}'
-                ))
+                StringReader(format),
+                f'format ordering as some order of the set {set(range(parse_value.order))}'
+            ))
         else:
             return parse_result

--- a/src/tensora/function.py
+++ b/src/tensora/function.py
@@ -122,11 +122,11 @@ def tensor_method(assignment: str, input_formats: Dict[str, str], output_format:
 def cachable_tensor_method(assignment: str, input_formats: Tuple[Tuple[str, str], ...], output_format: str
                            ) -> PureTensorMethod:
     from .expression.parser import parse_assignment
-    parsed_assignment = parse_assignment(assignment).or_die()
+    parsed_assignment = parse_assignment(assignment).unwrap()
 
-    parsed_input_formats = {name: parse_format(format).or_die() for name, format in input_formats}
+    parsed_input_formats = {name: parse_format(format).unwrap() for name, format in input_formats}
 
-    parsed_output = parse_format(output_format).or_die()
+    parsed_output = parse_format(output_format).unwrap()
 
     if parsed_assignment.is_mutating():
         raise NotImplementedError(f'Mutating tensor assignments like {assignment} not implemented yet.')

--- a/src/tensora/tensor.py
+++ b/src/tensora/tensor.py
@@ -50,7 +50,7 @@ class Tensor:
             coordinates = list(coordinates)
             format = default_format_given_nnz(dimensions, len(coordinates))
         elif isinstance(format, str):
-            format = parse_format(format).or_die()
+            format = parse_format(format).unwrap()
 
         # Reorder with first level first, etc.
         level_dimensions = tuple(dimensions[i] for i in format.ordering)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -23,7 +23,7 @@ assignment_strings = [
 
 @pytest.mark.parametrize('string,assignment', assignment_strings)
 def test_assignment_parsing(string, assignment):
-    actual = parse_assignment(string).or_die()
+    actual = parse_assignment(string).unwrap()
     assert actual == assignment
 
 
@@ -34,7 +34,7 @@ def test_assignment_deparsing(string, assignment):
 
 
 def parse(string):
-    return parse_assignment(string).or_die()
+    return parse_assignment(string).unwrap()
 
 
 def test_assignment_to_string():

--- a/tests/test_format.py
+++ b/tests/test_format.py
@@ -17,7 +17,7 @@ format_strings = [
 
 @pytest.mark.parametrize('string,format', format_strings)
 def test_parse_format(string, format):
-    actual = parse_format(string).or_die()
+    actual = parse_format(string).unwrap()
     assert actual == format
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, numpy, coverage, pep8
     3.9: py39
     3.10: py310
@@ -14,7 +13,6 @@ requires =
 
 # Environment changes have to be manually synced with `.github/workflows/python.yml`.
 envlist =
-    py37
     py38
     py39
     py310


### PR DESCRIPTION
Parsita is about to release version 2.0.0. Upgrade to the beta of that major release for testing. Drop support for Python 3.7 in keeping with the Parsita change.