### PR TITLE
Add tensora CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 cffi ~= 1.11
 parsita ~= 2.0
+typer ~= 0.9

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import platform
 import subprocess
 from distutils.command.build import build
+from importlib.metadata import entry_points
 from pathlib import Path
 
 from setuptools import find_packages, setup
@@ -83,4 +84,5 @@ setup(
         "bdist_wheel": TensoraBdistWheel,
     },
     zip_safe=False,
+    entry_points={"console_scripts": ["tensora=tensora.cli:app"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import platform
 import subprocess
 from distutils.command.build import build
-from importlib.metadata import entry_points
 from pathlib import Path
 
 from setuptools import find_packages, setup

--- a/src/tensora/cli.py
+++ b/src/tensora/cli.py
@@ -1,0 +1,105 @@
+__all__ = ["app"]
+
+from pathlib import Path
+from typing import Annotated, Optional
+
+import typer
+from parsita import Failure, Success
+
+from .expression import parse_assignment
+from .format import Format, Mode, parse_format
+from .kernel_type import KernelType
+from .native import generate_c_code_from_parsed
+
+app = typer.Typer()
+
+
+@app.command()
+def tensora(
+    assignment: Annotated[
+        str,
+        typer.Argument(
+            show_default=False,
+            help="The assignment for which to generate code, e.g. y(i) = A(i,j) * x(j).",
+        ),
+    ],
+    target_format_strings: Annotated[
+        list[str],
+        typer.Option(
+            "--format",
+            "-f",
+            help=(
+                "A tensor and its format separated by a colon, e.g. A:d1s0 for CSR matrix. "
+                "Unmentioned tensors are be assumed to be all dense."
+            ),
+        ),
+    ] = [],
+    kernel_types: Annotated[
+        list[KernelType],
+        typer.Option(
+            "--type",
+            "-t",
+            help="The type of kernel that will be generated. Can be mentioned multiple times.",
+        ),
+    ] = [KernelType.compute],
+    output_path: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output",
+            "-o",
+            writable=True,
+            help=(
+                "The file to which the kernel will be written. If not specified, prints to "
+                "standard out."
+            ),
+        ),
+    ] = None,
+):
+    # Parse assignment
+    match parse_assignment(assignment):
+        case Failure(error):
+            typer.echo(f"Failed to parse assignment:\n{error}", err=True)
+            raise typer.Exit(1)
+        case Success(sugar):
+            sugar = sugar
+
+    # Parse formats
+    parsed_formats = {}
+    for target_format_string in target_format_strings:
+        split_format = target_format_string.split(":")
+        if len(split_format) != 2:
+            typer.echo(
+                f"Format must be of the form 'target:format_string': {target_format_string}",
+                err=True,
+            )
+            raise typer.Exit(1)
+
+        target, format_string = split_format
+
+        if target in parsed_formats:
+            typer.echo(f"Format for {target} was mentioned multiple times", err=True)
+            raise typer.Exit(1)
+
+        match parse_format(format_string):
+            case Failure(error):
+                typer.echo(f"Failed to parse format:\n{error}", err=True)
+                typer.Exit(1)
+            case Success(format):
+                parsed_formats[target] = format
+
+    # Fill in missing formats with dense formats
+    # Use the order of variable_orders to determine the parameter order
+    formats = {}
+    for variable_name, order in sugar.variable_orders().items():
+        if variable_name in parsed_formats:
+            formats[variable_name] = parsed_formats[variable_name]
+        else:
+            formats[variable_name] = Format((Mode.dense,) * order, tuple(range(order)))
+
+    # Generate code
+    code = generate_c_code_from_parsed(sugar, formats, kernel_types)
+
+    if output_path is None:
+        typer.echo(code)
+    else:
+        output_path.write_text(code)

--- a/src/tensora/iteration_graph/generate_ir.py
+++ b/src/tensora/iteration_graph/generate_ir.py
@@ -341,7 +341,7 @@ def generate_ir(definition: Definition, graph: IterationGraph, kernel_type: Kern
 
     # Function declaration
     parameters = {name: types.Pointer(types.tensor) for name in definition.formats.keys()}
-    with source.function_definition("evaluate", parameters, types.integer):
+    with source.function_definition(kernel_type.name, parameters, types.integer):
         # Dimensions of all index variables
         with source.block("Extract dimensions"):
             for index_name, tensor_layer in definition.indexes.items():

--- a/src/tensora/kernel_type.py
+++ b/src/tensora/kernel_type.py
@@ -1,12 +1,13 @@
 __all__ = ["KernelType"]
 
-from enum import StrEnum, auto
+from enum import Enum
 
 
-class KernelType(StrEnum):
-    assembly = auto()
-    compute = auto()
-    evaluate = auto()
+class KernelType(str, Enum):
+    # Python 3.10 does not support StrEnum, so do it manually
+    assembly = "assembly"
+    compute = "compute"
+    evaluate = "evaluate"
 
     def is_assembly(self):
         return self == KernelType.assembly or self == KernelType.evaluate

--- a/src/tensora/kernel_type.py
+++ b/src/tensora/kernel_type.py
@@ -1,9 +1,9 @@
 __all__ = ["KernelType"]
 
-from enum import Enum, auto
+from enum import StrEnum, auto
 
 
-class KernelType(Enum):
+class KernelType(StrEnum):
     assembly = auto()
     compute = auto()
     evaluate = auto()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from typer.testing import CliRunner
+
+from tensora.cli import app
+
+runner = CliRunner()
+
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Usage:" in result.stdout
+    assert "Options" in result.stdout
+
+
+def test_cli():
+    result = runner.invoke(app, ["y(i) = A(i,j) * x(j)", "-f", "A:ds"])
+
+    assert result.exit_code == 0
+    assert result.stdout.startswith("int32_t compute(taco_tensor_t* restrict y,")
+
+
+def test_multiple_kernels():
+    result = runner.invoke(
+        app, ["y(i) = A(i,j) * x(j)", "-t", "compute", "-t", "evaluate", "-t", "assembly"]
+    )
+
+    assert result.exit_code == 0
+    assert "compute" in result.stdout
+    assert "evaluate" in result.stdout
+    assert "assembly" in result.stdout
+
+
+def test_write_to_file():
+    with NamedTemporaryFile(suffix=".c") as f:
+        result = runner.invoke(app, ["y(i) = A(i,j) * x(j)", "-o", f.name])
+
+        assert result.exit_code == 0
+        assert result.stdout == ""
+
+        assert Path(f.name).read_text().startswith("int32_t compute(taco_tensor_t* restrict y,")


### PR DESCRIPTION
This adds a Typer script called `tensora` to the Python entry points of the distribution. This CLI takes an assignment string and format strings to generate the C code. Either assembly, compute, or evaluate kernels can be generated. The code can be printed to standard out or to a file.