### PR TITLE
Add fuzz test infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 venv
 dist
 src/tensora/taco
+.hypothesis

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,8 +5,10 @@ cmake >= 3.13.3
 nox >= 2023.4.22
 
 # Test
-pytest >= 4.4.1
-pytest-cov >= 2.6.1
+pytest == 7.3.1
+pytest-cov == 4.1.0
+hypothesis == 6.75.7
+hypofuzz == 23.7.1
 
 # Lint
-ruff >= 0.1.5
+ruff == 0.1.6

--- a/fuzz_tests/test_cli.py
+++ b/fuzz_tests/test_cli.py
@@ -1,0 +1,12 @@
+from hypothesis import given
+from hypothesis import strategies as st
+from typer.testing import CliRunner
+
+from tensora.cli import app
+
+runner = CliRunner()
+
+
+@given(command=st.lists(st.text()))
+def test_cli_cannot_crash(command):
+    _ = runner.invoke(app, command, catch_exceptions=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,11 @@ def coverage(s: Session):
 
 
 @session(venv_backend="none")
+def fuzz(s: Session):
+    s.run("hypothesis", "fuzz", "fuzz_tests")
+
+
+@session(venv_backend="none")
 @parametrize("command", [["ruff", "check", "."], ["ruff", "format", "--check", "."]])
 def lint(s: Session, command: list[str]):
     s.run(*command)


### PR DESCRIPTION
This only adds one test: testing that the CLI exits gracefully on all possible input. Hopefully, more tests are to come.

This also pins some dev dependencies because some incompatibilities were encountered.