### PR TITLE
Assume away null bytes in CLI fuzz test

### DIFF
--- a/fuzz_tests/test_cli.py
+++ b/fuzz_tests/test_cli.py
@@ -1,4 +1,4 @@
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from typer.testing import CliRunner
 
@@ -9,4 +9,7 @@ runner = CliRunner()
 
 @given(command=st.lists(st.text()))
 def test_cli_cannot_crash(command):
+    # Arguments to a CLI cannot contain null bytes.
+    assume(not any("\0" in string for string in command))
+
     _ = runner.invoke(app, command, catch_exceptions=False)


### PR DESCRIPTION
Null bytes in the CLI fuzz test causes a crash. This cannot actually happen at the command line, so assume that they will not happen.