### PR TITLE
Refactor TensorMethod

### DIFF
--- a/fuzz_tests/test_generate.py
+++ b/fuzz_tests/test_generate.py
@@ -1,7 +1,7 @@
 from hypothesis import given
 
 from tensora.desugar import DiagonalAccessError, NoKernelFoundError
-from tensora.function import PureTensorMethod
+from tensora.function import TensorMethod
 
 from .strategies import problem_and_tensors
 
@@ -10,15 +10,8 @@ from .strategies import problem_and_tensors
 def test_generate_cannot_crash(problem_inputs):
     problem, input_tensors = problem_inputs
 
-    input_formats = {
-        name: format
-        for name, format in problem.formats.items()
-        if name != problem.assignment.target.name
-    }
-    output_format = problem.formats[problem.assignment.target.name]
-
     try:
-        method = PureTensorMethod(problem.assignment, input_formats, output_format)
+        method = TensorMethod(problem)
     except (DiagonalAccessError, NoKernelFoundError):
         return
 

--- a/src/tensora/desugar/ast.py
+++ b/src/tensora/desugar/ast.py
@@ -35,7 +35,7 @@ class Float(Literal):
 class Tensor(Expression):
     id: int
     name: str
-    indexes: list[str]
+    indexes: tuple[str, ...]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tensora/expression/_parser.py
+++ b/src/tensora/expression/_parser.py
@@ -30,7 +30,7 @@ class TensorExpressionParsers(ParserContext, whitespace=r"[ ]*"):
     integer = reg(r"[0-9]+") > (lambda x: Integer(int(x)))
     number = floating_point | integer
 
-    tensor = name & "(" >> repsep(name, ",") << ")" > splat(Tensor)
+    tensor = name & "(" >> (repsep(name, ",") > tuple) << ")" > splat(Tensor)
 
     parentheses = "(" >> expression << ")"  # noqa: F821
     factor = tensor | number | parentheses

--- a/src/tensora/expression/ast.py
+++ b/src/tensora/expression/ast.py
@@ -26,7 +26,7 @@ class Expression:
     @abstractmethod
     def deparse(self) -> str:
         """Convert the assignment back into a string."""
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def index_participants(self) -> dict[str, set[tuple[str, int]]]:
@@ -37,7 +37,7 @@ class Expression:
             pairs. In each pair, the first element is the name of a tensor and the second element
             is the dimension in which that index appears.
         """
-        pass
+        raise NotImplementedError()
 
     def __str__(self):
         return self.deparse()
@@ -72,7 +72,7 @@ class Float(Literal):
 @dataclass(frozen=True, slots=True)
 class Tensor(Expression):
     name: str
-    indexes: list[str]
+    indexes: tuple[str, ...]
 
     @property
     def order(self):

--- a/src/tensora/problem.py
+++ b/src/tensora/problem.py
@@ -74,6 +74,18 @@ class Problem:
                     name, self.formats[name].order, order, self.assignment
                 )
 
+    def __eq__(self, other: object):
+        if isinstance(other, Problem):
+            # Problems are only equal if the formats orders are equal
+            return self.assignment == other.assignment and tuple(self.formats.items()) == tuple(
+                other.formats.items()
+            )
+        else:
+            return NotImplemented
+
+    def __hash__(self) -> int:
+        return hash((self.assignment, tuple(self.formats.items())))
+
 
 def make_problem(
     assignment: Assignment, formats: dict[str, Format]

--- a/tests/test_desugar.py
+++ b/tests/test_desugar.py
@@ -10,57 +10,57 @@ from tensora.expression import ast as sugar
     [
         [
             sugar.Assignment(
-                sugar.Tensor("a", ["i"]),
-                sugar.Add(sugar.Tensor("b", ["i"]), sugar.Tensor("c", ["i"])),
+                sugar.Tensor("a", ("i",)),
+                sugar.Add(sugar.Tensor("b", ("i",)), sugar.Tensor("c", ("i",))),
             ),
             desugar.Assignment(
-                desugar.Tensor(0, "a", ["i"]),
-                desugar.Add(desugar.Tensor(1, "b", ["i"]), desugar.Tensor(2, "c", ["i"])),
+                desugar.Tensor(0, "a", ("i",)),
+                desugar.Add(desugar.Tensor(1, "b", ("i",)), desugar.Tensor(2, "c", ("i",))),
             ),
         ],
         [
             sugar.Assignment(
-                sugar.Tensor("A", ["i", "j"]),
-                sugar.Multiply(sugar.Tensor("B", ["i", "k"]), sugar.Tensor("C", ["k", "i"])),
+                sugar.Tensor("A", ("i", "j")),
+                sugar.Multiply(sugar.Tensor("B", ("i", "k")), sugar.Tensor("C", ("k", "i"))),
             ),
             desugar.Assignment(
-                desugar.Tensor(0, "A", ["i", "j"]),
+                desugar.Tensor(0, "A", ("i", "j")),
                 desugar.Contract(
                     "k",
                     desugar.Multiply(
-                        desugar.Tensor(1, "B", ["i", "k"]),
-                        desugar.Tensor(2, "C", ["k", "i"]),
+                        desugar.Tensor(1, "B", ("i", "k")),
+                        desugar.Tensor(2, "C", ("k", "i")),
                     ),
                 ),
             ),
         ],
         [
             sugar.Assignment(
-                sugar.Tensor("A", ["i", "j"]),
+                sugar.Tensor("A", ("i", "j")),
                 sugar.Add(
-                    sugar.Tensor("K", ["i", "j"]),
-                    sugar.Multiply(sugar.Tensor("B", ["i", "k"]), sugar.Tensor("C", ["k", "i"])),
+                    sugar.Tensor("K", ("i", "j")),
+                    sugar.Multiply(sugar.Tensor("B", ("i", "k")), sugar.Tensor("C", ("k", "i"))),
                 ),
             ),
             desugar.Assignment(
-                desugar.Tensor(0, "A", ["i", "j"]),
+                desugar.Tensor(0, "A", ("i", "j")),
                 desugar.Add(
-                    desugar.Tensor(1, "K", ["i", "j"]),
+                    desugar.Tensor(1, "K", ("i", "j")),
                     desugar.Contract(
                         "k",
                         desugar.Multiply(
-                            desugar.Tensor(2, "B", ["i", "k"]),
-                            desugar.Tensor(3, "C", ["k", "i"]),
+                            desugar.Tensor(2, "B", ("i", "k")),
+                            desugar.Tensor(3, "C", ("k", "i")),
                         ),
                     ),
                 ),
             ),
         ],
         [
-            sugar.Assignment(sugar.Tensor("a", ["i"]), sugar.Tensor("b", ["i", "j"])),
+            sugar.Assignment(sugar.Tensor("a", ("i",)), sugar.Tensor("b", ("i", "j"))),
             desugar.Assignment(
-                desugar.Tensor(0, "a", ["i"]),
-                desugar.Contract("j", desugar.Tensor(1, "b", ["i", "j"])),
+                desugar.Tensor(0, "a", ("i",)),
+                desugar.Contract("j", desugar.Tensor(1, "b", ("i", "j"))),
             ),
         ],
     ],

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -10,32 +10,32 @@ from tensora.expression.ast import *
 assignment_strings = [
     (
         "A(i) = B(i,j) * C(j)",
-        Assignment(Tensor("A", ["i"]), Multiply(Tensor("B", ["i", "j"]), Tensor("C", ["j"]))),
+        Assignment(Tensor("A", ("i",)), Multiply(Tensor("B", ("i", "j")), Tensor("C", ("j",)))),
     ),
     (
         "ab(i) = a(i) + b(i)",
-        Assignment(Tensor("ab", ["i"]), Add(Tensor("a", ["i"]), Tensor("b", ["i"]))),
+        Assignment(Tensor("ab", ("i",)), Add(Tensor("a", ("i",)), Tensor("b", ("i",)))),
     ),
     (
         "D(i) = A(i) - B(i)",
-        Assignment(Tensor("D", ["i"]), Subtract(Tensor("A", ["i"]), Tensor("B", ["i"]))),
+        Assignment(Tensor("D", ("i",)), Subtract(Tensor("A", ("i",)), Tensor("B", ("i",)))),
     ),
     (
         "B2(i) = 2.0 * B(i)",
-        Assignment(Tensor("B2", ["i"]), Multiply(Float(2.0), Tensor("B", ["i"]))),
+        Assignment(Tensor("B2", ("i",)), Multiply(Float(2.0), Tensor("B", ("i",)))),
     ),
     (
         "ab2(i) = 2.0 * (a(i) + b(i))",
         Assignment(
-            Tensor("ab2", ["i"]),
-            Multiply(Float(2.0), Add(Tensor("a", ["i"]), Tensor("b", ["i"]))),
+            Tensor("ab2", ("i",)),
+            Multiply(Float(2.0), Add(Tensor("a", ("i",)), Tensor("b", ("i",)))),
         ),
     ),
     (
         "ab2(i) = (a(i) + b(i)) * 2.0",
         Assignment(
-            Tensor("ab2", ["i"]),
-            Multiply(Add(Tensor("a", ["i"]), Tensor("b", ["i"])), Float(2.0)),
+            Tensor("ab2", ("i",)),
+            Multiply(Add(Tensor("a", ("i",)), Tensor("b", ("i",))), Float(2.0)),
         ),
     ),
 ]

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -20,9 +20,9 @@ def test_csr_matrix_vector_product(evaluate, compiler):
 
     expected = Tensor.from_aos([[0], [1]], [-5.0, 14.0], dimensions=(2,), format="d")
 
-    function = tensor_method("y(i) = A(i,j) * x(j)", dict(A="ds", x="d"), "d", compiler=compiler)
+    function = tensor_method("y(i) = A(i,j) * x(j)", dict(A="ds"), compiler=compiler)
 
-    actual = function(A, x)
+    actual = function(A=A, x=x)
 
     assert actual == expected
 
@@ -40,9 +40,9 @@ def test_csc_matrix_vector_product(evaluate, compiler):
 
     expected = Tensor.from_aos([[0], [1]], [-5.0, 14.0], dimensions=(2,), format="d")
 
-    function = tensor_method("y(i) = A(i,j) * x(j)", dict(A="d1s0", x="d"), "d", compiler=compiler)
+    function = tensor_method("y(i) = A(i,j) * x(j)", dict(A="d1s0"), compiler=compiler)
 
-    actual = function(A, x)
+    actual = function(A=A, x=x)
 
     assert actual == expected
 
@@ -64,10 +64,10 @@ def test_csr_matrix_plus_csr_matrix(evaluate, compiler):
     )
 
     function = tensor_method(
-        "C(i,j) = A(i,j) + B(i,j)", dict(A="ds", B="ds"), "ds", compiler=compiler
+        "C(i,j) = A(i,j) + B(i,j)", dict(C="ds", A="ds", B="ds"), compiler=compiler
     )
 
-    actual = function(A, B)
+    actual = function(A=A, B=B)
 
     assert actual == expected
 
@@ -90,11 +90,11 @@ def test_rhs(evaluate, compiler):
     expected = Tensor.from_lol([5, 0, -3])
 
     assignment = "f(i) = A0(i) + A1(i,j) * x(j) + A2(i,k,l) * x(k) * x(l)"
-    formats = {"A0": "d", "A1": "ds", "A2": "dss", "x": "d"}
+    formats = {"f": "d", "A0": "d", "A1": "ds", "A2": "dss", "x": "d"}
 
-    function = tensor_method(assignment, formats, "d", compiler=compiler)
+    function = tensor_method(assignment, formats, compiler=compiler)
 
-    actual = function(A0, A1, A2, x)
+    actual = function(A0=A0, A1=A1, A2=A2, x=x)
 
     assert actual == expected
 
@@ -129,7 +129,7 @@ def test_diagonal_error(evaluate, compiler):
         pytest.skip("We do not currently get a nice error from Taco")
 
     with pytest.raises(DiagonalAccessError):
-        tensor_method("a(i) = A(i,i)", dict(A="dd"), "d", compiler)
+        tensor_method("a(i) = A(i,i)", dict(a="d", A="dd"), compiler)
 
 
 def test_no_solution(evaluate, compiler):
@@ -137,4 +137,4 @@ def test_no_solution(evaluate, compiler):
         pytest.xfail("Taco currently segfaults on this")
 
     with pytest.raises(NoKernelFoundError):
-        tensor_method("A(i,j) = B(i,j) + C(j,i)", dict(B="ds", C="ds"), "ds", compiler)
+        tensor_method("A(i,j) = B(i,j) + C(j,i)", dict(A="ds", B="ds", C="ds"), compiler)


### PR DESCRIPTION
* Rename PureTensorMethod to TensorMethod
* Base TensorMethod on Problem
* Make tensor method parameters keyword only
* Make most attributes of TensorMethod private
* Make all AST objects fully immutable so that they are hashable