### PR TITLE
Fix fuzz tests

### DIFF
--- a/fuzz_tests/strategies.py
+++ b/fuzz_tests/strategies.py
@@ -7,7 +7,9 @@ from tensora.format import Format, Mode
 from tensora.problem import Problem
 
 names = st.from_regex(r"[A-Za-z][A-Za-z0-9]*", fullmatch=True)
-variables = st.builds(ast.Tensor, name=names, indexes=st.lists(names, max_size=16))
+variables = st.builds(
+    ast.Tensor, name=names, indexes=st.builds(tuple, st.lists(names, max_size=16))
+)
 expressions = st.deferred(
     lambda: st.builds(ast.Integer, st.integers(min_value=0))
     | st.builds(ast.Float, st.floats(min_value=0, allow_infinity=False, allow_nan=False))

--- a/fuzz_tests/test_generate.py
+++ b/fuzz_tests/test_generate.py
@@ -1,7 +1,7 @@
 from hypothesis import given
 
 from tensora.desugar import DiagonalAccessError, NoKernelFoundError
-from tensora.function import TensorMethod
+from tensora.function import BroadcastTargetIndexError, TensorMethod
 
 from .strategies import problem_and_tensors
 
@@ -12,7 +12,7 @@ def test_generate_cannot_crash(problem_inputs):
 
     try:
         method = TensorMethod(problem)
-    except (DiagonalAccessError, NoKernelFoundError):
+    except (BroadcastTargetIndexError, DiagonalAccessError, NoKernelFoundError):
         return
 
     _ = method(**input_tensors)


### PR DESCRIPTION
The fuzz tests were broken by #44 and #45. Once I figure out why `test_generate.py` hangs in Hypothesis sometimes, I can add them all to CI.