### PR TITLE
Check for name conflicts between tensors and indexes

### DIFF
--- a/fuzz_tests/test_parsing.py
+++ b/fuzz_tests/test_parsing.py
@@ -6,6 +6,7 @@ from returns.result import Failure, Success
 from tensora.expression import (
     InconsistentDimensionsError,
     MutatingAssignmentError,
+    NameConflictError,
     ast,
     parse_assignment,
 )
@@ -37,7 +38,12 @@ def test_expression_parsing_cannot_crash(string):
     match parse_assignment(string):
         case Success(ast.Assignment()):
             pass
-        case Failure(ParseError() | MutatingAssignmentError() | InconsistentDimensionsError()):
+        case Failure(
+            ParseError()
+            | MutatingAssignmentError()
+            | InconsistentDimensionsError()
+            | NameConflictError()
+        ):
             pass
         case _:
             assert False

--- a/src/tensora/expression/__init__.py
+++ b/src/tensora/expression/__init__.py
@@ -1,2 +1,2 @@
-from ._exceptions import InconsistentDimensionsError, MutatingAssignmentError
+from ._exceptions import InconsistentDimensionsError, MutatingAssignmentError, NameConflictError
 from ._parser import parse_assignment

--- a/src/tensora/expression/_exceptions.py
+++ b/src/tensora/expression/_exceptions.py
@@ -1,4 +1,4 @@
-__all__ = ["MutatingAssignmentError", "InconsistentDimensionsError"]
+__all__ = ["MutatingAssignmentError", "InconsistentDimensionsError", "NameConflictError"]
 
 from dataclasses import dataclass
 
@@ -27,4 +27,16 @@ class InconsistentDimensionsError(Exception):
             f"Expected each tensor in an assignment to be referenced with the same number of "
             f"indexes, but found parameter {self.first.name} referenced as {self.first} and then "
             f"as {self.second} in {self.assignment}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class NameConflictError(Exception):
+    name: str
+    assignment: Assignment
+
+    def __str__(self):
+        return (
+            f"Expected no tensor and index to have the same name, but found {self.name} as both a "
+            f"tensor and an index in {self.assignment}"
         )

--- a/src/tensora/expression/_parser.py
+++ b/src/tensora/expression/_parser.py
@@ -6,7 +6,7 @@ from parsita import ParseError, ParserContext, lit, reg, rep, rep1sep, repsep
 from parsita.util import splat
 from returns import result
 
-from ._exceptions import InconsistentDimensionsError, MutatingAssignmentError
+from ._exceptions import InconsistentDimensionsError, MutatingAssignmentError, NameConflictError
 from .ast import Add, Assignment, Float, Integer, Multiply, Subtract, Tensor
 
 
@@ -43,8 +43,11 @@ class TensorExpressionParsers(ParserContext, whitespace=r"[ ]*"):
 
 def parse_assignment(
     string: str
-) -> result.Result[Assignment, ParseError | MutatingAssignmentError | InconsistentDimensionsError]:
+) -> result.Result[
+    Assignment,
+    ParseError | MutatingAssignmentError | InconsistentDimensionsError | NameConflictError,
+]:
     try:
         return TensorExpressionParsers.assignment.parse(string)
-    except (MutatingAssignmentError, InconsistentDimensionsError) as e:
+    except (MutatingAssignmentError, InconsistentDimensionsError, NameConflictError) as e:
         return result.Failure(e)

--- a/tests/test_expression.py
+++ b/tests/test_expression.py
@@ -3,6 +3,7 @@ import pytest
 from tensora.expression import (
     InconsistentDimensionsError,
     MutatingAssignmentError,
+    NameConflictError,
     parse_assignment,
 )
 from tensora.expression.ast import *
@@ -68,6 +69,21 @@ def test_mutating_assignment():
 )
 def test_inconsistent_variable_size(assignment):
     assert isinstance(parse_assignment(assignment).failure(), InconsistentDimensionsError)
+
+
+@pytest.mark.parametrize(
+    "assignment",
+    [
+        "A(i) = B(B)",
+        "A(i) = B(i,j) * C(j,B)",
+        "A(i) = C(j,B) * B(i,j)",
+        "A(A) = B(i)",
+        "A(i) = B(A)",
+        "A(B) = B(i)",
+    ],
+)
+def test_name_conflict(assignment):
+    assert isinstance(parse_assignment(assignment).failure(), NameConflictError)
 
 
 def parse(string):


### PR DESCRIPTION
Tensors and indexes having the same names should not be allowed because this causes name conflicts in the code generation. It is also just bad hygiene. This make this an error at Assignment-creation time.