### PR TITLE
Use strict zip everywhere

### DIFF
--- a/src/tensora/compile.py
+++ b/src/tensora/compile.py
@@ -331,7 +331,7 @@ def taco_structure_to_cffi(
     memory_holder = global_weakkeydict[cffi_tensor]
 
     cffi_indices = tensor_cdefs.cast("int32_t***", cffi_tensor.indices)
-    for i_level, (mode, level) in enumerate(zip(mode_types, indices)):
+    for i_level, (mode, level) in enumerate(zip(mode_types, indices, strict=True)):
         if mode == tensor_lib.taco_mode_dense:
             pass
         elif mode == tensor_lib.taco_mode_sparse:
@@ -448,4 +448,4 @@ def take_ownership_of_tensor(cffi_tensor) -> None:
 
 
 def weakly_increasing(list: list[int]):
-    return all(x <= y for x, y in zip(list, list[1:]))
+    return all(x <= y for x, y in zip(list[:-1], list[1:], strict=True))

--- a/src/tensora/format/_format.py
+++ b/src/tensora/format/_format.py
@@ -46,5 +46,6 @@ class Format:
             return "".join(mode.character for mode in self.modes)
         else:
             return "".join(
-                mode.character + str(ordering) for mode, ordering in zip(self.modes, self.ordering)
+                mode.character + str(ordering)
+                for mode, ordering in zip(self.modes, self.ordering, strict=True)
             )

--- a/src/tensora/function.py
+++ b/src/tensora/function.py
@@ -73,7 +73,10 @@ class TensorMethod:
 
         # Validate tensor arguments
         for name, argument, format in zip(
-            bound_arguments.keys(), bound_arguments.values(), self._input_formats.values()
+            bound_arguments.keys(),
+            bound_arguments.values(),
+            self._input_formats.values(),
+            strict=True,
         ):
             if not isinstance(argument, Tensor):
                 raise TypeError(f"Argument {name} must be a Tensor not {type(argument)}")

--- a/src/tensora/iteration_graph/outputs/_bucket.py
+++ b/src/tensora/iteration_graph/outputs/_bucket.py
@@ -60,7 +60,7 @@ class BucketOutput(Output):
     def ravel_indexes(self, dimensions: list[Variable], indexes: list[Variable]):
         dimensions_so_far: list[Variable] = []
         terms: list[Expression] = []
-        for dim_i, index_i in zip(reversed(dimensions), reversed(indexes)):
+        for dim_i, index_i in zip(reversed(dimensions), reversed(indexes), strict=True):
             terms.append(Multiply.join([index_i] + dimensions_so_far))
             dimensions_so_far.append(dim_i)
 


### PR DESCRIPTION
The `strict=True` option was added to `zip` in Python 3.10. This is good option to enable on all `zip` calls. There is no explicit Python version that Tensora supports, but only versions above 3.10 are tested in CI.