### PR TITLE
Add Module to IR

### DIFF
--- a/src/tensora/codegen/__init__.py
+++ b/src/tensora/codegen/__init__.py
@@ -1,1 +1,1 @@
-from ._ir_to_c import ir_to_c
+from ._ir_to_c import ir_to_c, ir_to_c_function_definition, ir_to_c_statement

--- a/src/tensora/generate/_tensora.py
+++ b/src/tensora/generate/_tensora.py
@@ -11,7 +11,8 @@ from ..desugar import (
     index_dimensions,
     to_identifiable,
 )
-from ..ir import SourceBuilder, peephole
+from ..ir import peephole
+from ..ir.ast import Module
 from ..iteration_graph import Definition, generate_ir
 from ..kernel_type import KernelType
 from ..problem import Problem
@@ -36,8 +37,7 @@ def generate_c_code_tensora(
         case _:
             raise NotImplementedError()
 
-    ir = SourceBuilder()
-    for kernel_type in kernel_types:
-        ir.append(generate_ir(definition, graph, kernel_type).finalize())
+    functions = [generate_ir(definition, graph, kernel_type) for kernel_type in kernel_types]
+    module = Module(functions)
 
-    return Success(ir_to_c(peephole(ir.finalize())))
+    return Success(ir_to_c(peephole(module)))

--- a/src/tensora/ir/__init__.py
+++ b/src/tensora/ir/__init__.py
@@ -1,2 +1,2 @@
 from ._builder import SourceBuilder
-from ._peephole import peephole
+from ._peephole import peephole, peephole_function_definition, peephole_statement

--- a/src/tensora/ir/ast.py
+++ b/src/tensora/ir/ast.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Sequence
-
 __all__ = [
     "Statement",
     "Expression",
@@ -43,10 +41,12 @@ __all__ = [
     "Break",
     "Return",
     "FunctionDefinition",
+    "Module",
 ]
 
 from dataclasses import dataclass
 from functools import reduce
+from typing import Sequence
 
 from ..format import Mode
 from .types import Type
@@ -262,7 +262,7 @@ class Min(Expression):
 
 @dataclass(frozen=True, slots=True)
 class Address(Expression):
-    target: Variable
+    target: Assignable
 
 
 @dataclass(frozen=True, slots=True)
@@ -357,8 +357,13 @@ class Return(Statement):
 
 
 @dataclass(frozen=True, slots=True)
-class FunctionDefinition(Statement):
+class FunctionDefinition:
     name: Variable
     parameters: list[Declaration]
     return_type: Type
     body: Statement
+
+
+@dataclass(frozen=True, slots=True)
+class Module:
+    definitions: list[FunctionDefinition]


### PR DESCRIPTION
Currently, `FunctionDefinition`s are valid `Statement`s. This is not true in C. Pretending this is true make implementation of [LLVM conversion](#66) difficult. This adds the concept of a `Module` to the IR AST, which currently contains only a list of definitions, each of which currently can only be `FunctionDefinitions`.

`imports` may be added to `Module` in the future, but are not currently implemented.