### PR TITLE
Remove ArrayLiteral from IR

### DIFF
--- a/src/tensora/codegen/_ir_to_c.py
+++ b/src/tensora/codegen/_ir_to_c.py
@@ -10,7 +10,6 @@ from ..ir.ast import (
     And,
     ArrayAllocate,
     ArrayIndex,
-    ArrayLiteral,
     ArrayReallocate,
     Assignment,
     AttributeAccess,
@@ -101,11 +100,6 @@ def ir_to_c_mode_literal(self: ModeLiteral) -> str:
             return "taco_mode_dense"
         case Mode.compressed:
             return "taco_mode_sparse"
-
-
-@ir_to_c_expression.register(ArrayLiteral)
-def ir_to_c_array_literal(self: ArrayLiteral) -> str:
-    return "{" + ", ".join(map(ir_to_c_expression, self.elements)) + "}"
 
 
 @ir_to_c_expression.register(Add)

--- a/src/tensora/ir/_peephole.py
+++ b/src/tensora/ir/_peephole.py
@@ -31,7 +31,6 @@ from .ast import (
     And,
     ArrayAllocate,
     ArrayIndex,
-    ArrayLiteral,
     ArrayReallocate,
     Assignable,
     Assignment,
@@ -108,11 +107,6 @@ def peephole_expression_assignable(self: Assignable) -> Assignable:
 @peephole_expression.register(Allocate)
 def peephole_noop(self: Expression) -> Expression:
     return self
-
-
-@peephole_expression.register(ArrayLiteral)
-def peephole_array_literal(self: ArrayLiteral) -> Expression:
-    return ArrayLiteral([peephole_expression(element) for element in self.elements])
 
 
 @peephole_expression.register(Add)

--- a/src/tensora/ir/ast.py
+++ b/src/tensora/ir/ast.py
@@ -11,7 +11,6 @@ __all__ = [
     "FloatLiteral",
     "BooleanLiteral",
     "ModeLiteral",
-    "ArrayLiteral",
     "Add",
     "Subtract",
     "Multiply",
@@ -139,11 +138,6 @@ class BooleanLiteral(Expression):
 @dataclass(frozen=True, slots=True)
 class ModeLiteral(Expression):
     value: Mode
-
-
-@dataclass(frozen=True, slots=True)
-class ArrayLiteral(Expression):
-    elements: Sequence[Expression]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/codegen/test_ast_to_c.py
+++ b/tests/codegen/test_ast_to_c.py
@@ -21,7 +21,6 @@ single_lines = [
     (FloatLiteral(1.0), "1.0"),
     (BooleanLiteral(False), "0"),
     (BooleanLiteral(True), "1"),
-    (ArrayLiteral([Variable("x"), Variable("y")]), "{x, y}"),
     # Add
     (Add(Variable("x"), Variable("y")), "x + y"),
     (Add(Add(Variable("x"), Variable("y")), Variable("z")), "x + y + z"),

--- a/tests/ir/test_peephole.py
+++ b/tests/ir/test_peephole.py
@@ -81,10 +81,6 @@ changed = [
         AttributeAccess(ArrayIndex(Variable("x"), Variable("i")), "modes"),
     ),
     (
-        ArrayLiteral([Add(FloatLiteral(0.0), Variable("x"))]),
-        ArrayLiteral([Variable("x")]),
-    ),
-    (
         FunctionCall(Variable("f"), [Add(FloatLiteral(0.0), Variable("x"))]),
         FunctionCall(Variable("f"), [Variable("x")]),
     ),


### PR DESCRIPTION
This IR element is no longer needed since the [removal of HashOutput](#68).