### PR TITLE
Remove FunctionCall from IR

### DIFF
--- a/src/tensora/codegen/_ir_to_c.py
+++ b/src/tensora/codegen/_ir_to_c.py
@@ -24,7 +24,6 @@ from ..ir.ast import (
     Expression,
     FloatLiteral,
     Free,
-    FunctionCall,
     FunctionDefinition,
     GreaterThan,
     GreaterThanOrEqual,
@@ -157,11 +156,6 @@ def ir_to_c_and(self: And) -> str:
 @ir_to_c_expression.register(Or)
 def ir_to_c_or(self: Or) -> str:
     return f"{ir_to_c_expression(self.left)} || {ir_to_c_expression(self.right)}"
-
-
-@ir_to_c_expression.register(FunctionCall)
-def ir_to_c_function_call(self: FunctionCall) -> str:
-    return f"{ir_to_c_expression(self.name)}({', '.join(map(ir_to_c_expression, self.arguments))})"
 
 
 @ir_to_c_expression.register(Max)

--- a/src/tensora/ir/_peephole.py
+++ b/src/tensora/ir/_peephole.py
@@ -46,7 +46,6 @@ from .ast import (
     Expression,
     FloatLiteral,
     Free,
-    FunctionCall,
     FunctionDefinition,
     GreaterThan,
     GreaterThanOrEqual,
@@ -206,12 +205,6 @@ def peephole_or(self: Or) -> Expression:
         return left
     else:
         return Or(left, right)
-
-
-@peephole_expression.register(FunctionCall)
-def peephole_function_call(self: FunctionCall) -> Expression:
-    arguments = [peephole_expression(argument) for argument in self.arguments]
-    return replace(self, arguments=arguments)
 
 
 @peephole_expression.register(Max)

--- a/src/tensora/ir/ast.py
+++ b/src/tensora/ir/ast.py
@@ -22,7 +22,6 @@ __all__ = [
     "LessThanOrEqual",
     "And",
     "Or",
-    "FunctionCall",
     "Max",
     "Min",
     "Address",
@@ -224,12 +223,6 @@ class Or(Expression):
     def join(operands: Sequence[Expression | int | str]) -> Expression:
         expression_operands = [to_expression(operand) for operand in operands]
         return reduce(Or, expression_operands, BooleanLiteral(False))
-
-
-@dataclass(frozen=True, slots=True)
-class FunctionCall(Expression):
-    name: Variable
-    arguments: list[Expression]
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/codegen/test_ast_to_c.py
+++ b/tests/codegen/test_ast_to_c.py
@@ -55,9 +55,6 @@ single_lines = [
     # Boolean operators
     (And(Variable("x"), Variable("y")), "x && y"),
     (Or(Variable("x"), Variable("y")), "x || y"),
-    # Function call
-    (FunctionCall(Variable("f"), [Variable("x")]), "f(x)"),
-    (FunctionCall(Variable("f"), [Variable("x"), Variable("y")]), "f(x, y)"),
     # Max/min
     (Max(Variable("x"), Variable("y")), "TACO_MAX(x, y)"),
     (Min(Variable("x"), Variable("y")), "TACO_MIN(x, y)"),

--- a/tests/ir/test_peephole.py
+++ b/tests/ir/test_peephole.py
@@ -81,10 +81,6 @@ changed = [
         AttributeAccess(ArrayIndex(Variable("x"), Variable("i")), "modes"),
     ),
     (
-        FunctionCall(Variable("f"), [Add(FloatLiteral(0.0), Variable("x"))]),
-        FunctionCall(Variable("f"), [Variable("x")]),
-    ),
-    (
         BooleanToInteger(And(BooleanLiteral(True), Variable("t"))),
         BooleanToInteger(Variable("t")),
     ),
@@ -202,7 +198,6 @@ unchanged = [
     NotEqual(Variable("x"), Variable("y")),
     LessThan(Variable("x"), Variable("y")),
     GreaterThan(Variable("x"), Variable("y")),
-    FunctionCall(Variable("f"), [Variable("x")]),
     Loop(BooleanLiteral(True), Variable("x")),
     Assignment(Variable("x"), ArrayIndex(ArrayIndex(Variable("y"), Variable("i")), Variable("j"))),
     Break(),


### PR DESCRIPTION
This is no longer needed after the [removal of HashOutput](#68).