### PR TITLE
Remove Allocate, Free, and ModeLiteral from IR

### DIFF
--- a/src/tensora/codegen/_ir_to_c.py
+++ b/src/tensora/codegen/_ir_to_c.py
@@ -2,11 +2,8 @@ __all__ = ["ir_to_c_statement", "ir_to_c_function_definition", "ir_to_c"]
 
 from functools import singledispatch
 
-from ..format import Mode
 from ..ir.ast import (
     Add,
-    Address,
-    Allocate,
     And,
     ArrayAllocate,
     ArrayIndex,
@@ -22,7 +19,6 @@ from ..ir.ast import (
     Equal,
     Expression,
     FloatLiteral,
-    Free,
     FunctionDefinition,
     GreaterThan,
     GreaterThanOrEqual,
@@ -32,7 +28,6 @@ from ..ir.ast import (
     Loop,
     Max,
     Min,
-    ModeLiteral,
     Module,
     Multiply,
     NotEqual,
@@ -89,15 +84,6 @@ def ir_to_c_float_literal(self: FloatLiteral) -> str:
 @ir_to_c_expression.register(BooleanLiteral)
 def ir_to_c_boolean_literal(self: BooleanLiteral) -> str:
     return str(int(self.value))
-
-
-@ir_to_c_expression.register(ModeLiteral)
-def ir_to_c_mode_literal(self: ModeLiteral) -> str:
-    match self.value:
-        case Mode.dense:
-            return "taco_mode_dense"
-        case Mode.compressed:
-            return "taco_mode_sparse"
 
 
 @ir_to_c_expression.register(Add)
@@ -167,19 +153,9 @@ def ir_to_c_min(self: Min) -> str:
     return f"TACO_MIN({ir_to_c_expression(self.left)}, {ir_to_c_expression(self.right)})"
 
 
-@ir_to_c_expression.register(Address)
-def ir_to_c_address(self: Address) -> str:
-    return f"&{ir_to_c_expression(self.target)}"
-
-
 @ir_to_c_expression.register(BooleanToInteger)
 def ir_to_c_boolean_to_integer(self: BooleanToInteger) -> str:
     return f"(int32_t)({ir_to_c_expression(self.expression)})"
-
-
-@ir_to_c_expression.register(Allocate)
-def ir_to_c_allocate(self: Allocate) -> str:
-    return f"malloc(sizeof({type_to_c(self.type)}))"
 
 
 @ir_to_c_expression.register(ArrayAllocate)
@@ -206,11 +182,6 @@ def ir_to_c_statement(self: Statement) -> list[str]:
 def convert_expression_to_statement(self: Expression) -> list[str]:
     # Every expression can also be a statement; convert it here
     return [ir_to_c_expression(self) + ";"]
-
-
-@ir_to_c_statement.register(Free)
-def ir_to_c_free(self: Free) -> list[str]:
-    return [f"free({ir_to_c_expression(self.target)});"]
 
 
 @ir_to_c_statement.register(Declaration)

--- a/src/tensora/ir/_peephole.py
+++ b/src/tensora/ir/_peephole.py
@@ -26,8 +26,6 @@ from functools import singledispatch
 
 from .ast import (
     Add,
-    Address,
-    Allocate,
     And,
     ArrayAllocate,
     ArrayIndex,
@@ -44,7 +42,6 @@ from .ast import (
     Equal,
     Expression,
     FloatLiteral,
-    Free,
     FunctionDefinition,
     GreaterThan,
     GreaterThanOrEqual,
@@ -54,7 +51,6 @@ from .ast import (
     Loop,
     Max,
     Min,
-    ModeLiteral,
     Module,
     Multiply,
     NotEqual,
@@ -100,9 +96,6 @@ def peephole_expression_assignable(self: Assignable) -> Assignable:
 @peephole_expression.register(IntegerLiteral)
 @peephole_expression.register(FloatLiteral)
 @peephole_expression.register(BooleanLiteral)
-@peephole_expression.register(ModeLiteral)
-@peephole_expression.register(Address)
-@peephole_expression.register(Allocate)
 def peephole_noop(self: Expression) -> Expression:
     return self
 
@@ -255,11 +248,6 @@ def peephole_expression_statement(self: Expression) -> Expression:
 @peephole_statement.register(Declaration)
 def peephole_declaration(self: Declaration) -> Declaration:
     return self
-
-
-@peephole_statement.register(Free)
-def peephole_free(self: Free) -> Statement:
-    return Free(peephole_assignable(self.target))
 
 
 @peephole_statement.register(Assignment)

--- a/src/tensora/ir/ast.py
+++ b/src/tensora/ir/ast.py
@@ -10,7 +10,6 @@ __all__ = [
     "IntegerLiteral",
     "FloatLiteral",
     "BooleanLiteral",
-    "ModeLiteral",
     "Add",
     "Subtract",
     "Multiply",
@@ -24,12 +23,9 @@ __all__ = [
     "Or",
     "Max",
     "Min",
-    "Address",
     "BooleanToInteger",
-    "Allocate",
     "ArrayAllocate",
     "ArrayReallocate",
-    "Free",
     "Declaration",
     "Assignment",
     "DeclarationAssignment",
@@ -45,7 +41,6 @@ from dataclasses import dataclass
 from functools import reduce
 from typing import Sequence
 
-from ..format import Mode
 from .types import Type
 
 
@@ -131,11 +126,6 @@ class FloatLiteral(Expression):
 @dataclass(frozen=True, slots=True)
 class BooleanLiteral(Expression):
     value: bool
-
-
-@dataclass(frozen=True, slots=True)
-class ModeLiteral(Expression):
-    value: Mode
 
 
 @dataclass(frozen=True, slots=True)
@@ -247,18 +237,8 @@ class Min(Expression):
 
 
 @dataclass(frozen=True, slots=True)
-class Address(Expression):
-    target: Assignable
-
-
-@dataclass(frozen=True, slots=True)
 class BooleanToInteger(Expression):
     expression: Expression
-
-
-@dataclass(frozen=True, slots=True)
-class Allocate(Expression):
-    type: Type
 
 
 @dataclass(frozen=True, slots=True)
@@ -272,11 +252,6 @@ class ArrayReallocate(Expression):
     old: Assignable
     type: Type
     n_elements: Expression
-
-
-@dataclass(frozen=True, slots=True)
-class Free(Statement):
-    target: Assignable
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/codegen/test_ast_to_c.py
+++ b/tests/codegen/test_ast_to_c.py
@@ -60,13 +60,9 @@ single_lines = [
     (Min(Variable("x"), Variable("y")), "TACO_MIN(x, y)"),
     (Max(Max(Variable("x"), Variable("y")), Variable("z")), "TACO_MAX(TACO_MAX(x, y), z)"),
     (Min(Min(Variable("x"), Variable("y")), Variable("z")), "TACO_MIN(TACO_MIN(x, y), z)"),
-    # Address
-    (Address(Variable("x")), "&x"),
-    (Address(ArrayIndex(Variable("x"), Variable("i"))), "&x[i]"),
     # Cast
     (BooleanToInteger(Equal(Variable("x"), Variable("y"))), "(int32_t)(x == y)"),
     # Allocate
-    (Allocate(tensor), "malloc(sizeof(taco_tensor_t))"),
     (ArrayAllocate(integer, Variable("capacity")), "malloc(sizeof(int32_t) * capacity)"),
     (
         ArrayAllocate(float, Add(Variable("previous"), Variable("new"))),
@@ -80,8 +76,6 @@ single_lines = [
         ArrayReallocate(Variable("old"), float, Add(Variable("previous"), Variable("new"))),
         "realloc(old, sizeof(double) * (previous + new))",
     ),
-    # Free
-    (Free(Variable("x")), "free(x)"),
     # Declaration and types
     (Declaration(Variable("x"), integer), "int32_t x"),
     (Declaration(Variable("x"), float), "double x"),

--- a/tests/ir/test_peephole.py
+++ b/tests/ir/test_peephole.py
@@ -93,10 +93,6 @@ changed = [
         ArrayReallocate(Variable("x"), float, Variable("y")),
     ),
     (
-        Free(ArrayIndex(Variable("x"), Add(IntegerLiteral(0), Variable("y")))),
-        Free(ArrayIndex(Variable("x"), Variable("y"))),
-    ),
-    (
         Assignment(Variable("x"), Add(IntegerLiteral(0), Variable("y"))),
         Assignment(Variable("x"), Variable("y")),
     ),


### PR DESCRIPTION
These AST nodes are not needed after the [removal of `HashOutput`](#68).