### PR TITLE
Support Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           - ubuntu-22.04-arm
           - macos-13
           - macos-15
+          - windows-2025
         python:
           - "3.10"
           - "3.11"
@@ -32,11 +33,16 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           version: ${{ env.uv-version }}
-      - name: Test with nox
+      - name: Test with nox (all platforms)
         run: >-
           uv run --locked --only-group nox nox -s
           test-${{ matrix.python }}
           test_numpy-${{ matrix.python }}
+      - name: Test with nox (non-Windows)
+        if: runner.os != 'Windows'
+        run: >-
+          uv run --locked --only-group nox nox -s
+          test_cffi-${{ matrix.python }}
           test_taco-${{ matrix.python }}
       - name: Store coverage
         uses: actions/upload-artifact@v4

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,10 +13,10 @@ def test(s: Session):
     s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests")
 
 
-@session(python=["3.10", "3.11", "3.12", "3.13"], uv_groups=["test"], uv_extras=["taco"])
-def test_taco(s: Session):
-    coverage_file = f".coverage.{platform.machine()}.{platform.system()}.{s.python}.taco"
-    s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests/taco")
+@session(python=["3.10", "3.11", "3.12", "3.13"], uv_groups=["test"], uv_extras=["numpy"])
+def test_numpy(s: Session):
+    coverage_file = f".coverage.{platform.machine()}.{platform.system()}.{s.python}.numpy"
+    s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests/test_numpy.py")
 
 
 @session(python=["3.10", "3.11", "3.12", "3.13"], uv_groups=["test"], uv_extras=["cffi"])
@@ -25,10 +25,10 @@ def test_cffi(s: Session):
     s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests_cffi")
 
 
-@session(python=["3.10", "3.11", "3.12", "3.13"], uv_groups=["test"], uv_extras=["numpy"])
-def test_numpy(s: Session):
-    coverage_file = f".coverage.{platform.machine()}.{platform.system()}.{s.python}.numpy"
-    s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests/test_numpy.py")
+@session(python=["3.10", "3.11", "3.12", "3.13"], uv_groups=["test"], uv_extras=["taco"])
+def test_taco(s: Session):
+    coverage_file = f".coverage.{platform.machine()}.{platform.system()}.{s.python}.taco"
+    s.run("coverage", "run", "--data-file", coverage_file, "-m", "pytest", "tests/taco")
 
 
 @session(venv_backend="none")

--- a/src/tensora/compile/_cffi_ownership.py
+++ b/src/tensora/compile/_cffi_ownership.py
@@ -8,6 +8,7 @@ __all__ = [
     "tensor_cdefs",
 ]
 
+import platform
 from itertools import pairwise
 from weakref import WeakKeyDictionary
 
@@ -72,8 +73,12 @@ tensor_cdefs.cdef(taco_type_header)
 # This library only has definitions, in order to `include` it elsewhere, `set_source` must be called with empty `source` first
 tensor_cdefs.set_source("_main", "")
 
-# Open the base C library, which works on Linux and Mac
-tensor_lib = tensor_cdefs.dlopen(None)
+if platform.system() == "Windows":
+    # On Windows, standard C functions like free are in msvcrt.dll
+    tensor_lib = tensor_cdefs.dlopen("msvcrt.dll")
+else:
+    # On Linux and Mac, standard C functions like free are in the system C library
+    tensor_lib = tensor_cdefs.dlopen(None)
 
 
 def allocate_taco_structure(

--- a/src/tensora/compile/_tensor_method.py
+++ b/src/tensora/compile/_tensor_method.py
@@ -35,6 +35,18 @@ class BroadcastTargetIndexError(Exception):
 
 
 class BackendCompiler(Enum):
+    """The tool to generate the machine code.
+
+    Attributes
+    ----------
+    llvm
+        Generate LLVM IR and compile with the llvmlite package.
+        Not available with TensorCompiler.taco.
+    cffi
+        Generate C code and compile with the cffi package.
+        Not available on Windows.
+    """
+
     llvm = "llvm"
     cffi = "cffi"
 

--- a/src/tensora/generate/_base.py
+++ b/src/tensora/generate/_base.py
@@ -13,6 +13,19 @@ from ._tensora import generate_module_tensora
 
 
 class TensorCompiler(str, Enum):
+    """The tool to generate the tensor kernel.
+
+    Attributes
+    ----------
+    tensora
+        The tensor compiler included with Tensora.
+    taco
+        The original TACO binary repackaged in `tensora-taco`.
+        Only available via the `taco` extra.
+        Not compatible with `Language.llvm`.
+        Not available on Windows.
+    """
+
     # Python 3.10 does not support StrEnum, so do it manually
     tensora = "tensora"
     taco = "taco"
@@ -22,6 +35,17 @@ class TensorCompiler(str, Enum):
 
 
 class Language(str, Enum):
+    """The language to be generated.
+
+    Attributes
+    ----------
+    c
+        C language.
+    llvm
+        LLVM IR.
+        Not compatible with `TensorCompiler.taco`.
+    """
+
     # Python 3.10 does not support StrEnum, so do it manually
     c = "c"
     llvm = "llvm"


### PR DESCRIPTION
Support for Windows is added for the default case: Tensora as tensor compiler and LLVM as backend compiler. This does not support TACO as the tensor compiler or CFFI as the backend compiler. As such, the tests for those features are skipped in CI for Windows.