### PR TITLE
Support partial fusing of iterations in sum nodes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,13 +31,13 @@ uv sync
 Tensora uses pytest to run the tests in the `tests/` directory. The test command is encapsulated with Nox:
 
 ```shell
-uv run nox -s test test_taco test_numpy
+uv run nox -s test test_taco test_cffi test_numpy
 ```
 
 This will try to test with all compatible Python versions that `nox` can find. To run the tests with only a particular version, run something like this:
 
 ```shell
-uv run nox -s test-3.10 test_taco-3.10 test_numpy-3.10
+uv run nox -s test-3.10 test_taco-3.10 test_cffi-3.10 test_numpy-3.10
 ```
 
 It is good to run the tests locally before making a PR, but it is not necessary to have all Python versions run. It is rare for a failure to appear in a single version, and the CI will catch it anyway.

--- a/src/tensora/__init__.py
+++ b/src/tensora/__init__.py
@@ -1,4 +1,4 @@
-from .compile import evaluate, evaluate_taco, evaluate_tensora, tensor_method
+from .compile import BackendCompiler, evaluate, evaluate_taco, evaluate_tensora, tensor_method
 from .format import Format, Mode
 from .generate import TensorCompiler
 from .tensor import Tensor

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -1,0 +1,10 @@
+from tensora import Tensor, evaluate
+
+
+def test_sum_non_adjacent():
+    b = Tensor.from_lol([1, 2, 3])
+    c = Tensor.from_lol([[1, 3, 5], [2, 4, 6]])
+    d = Tensor.from_lol([7, 8, 9])
+    actual = evaluate("a(i) = b(i) + c(j,i) + d(i)", "d", b=b, c=c, d=d)
+    expected = Tensor.from_lol([11, 17, 23])
+    assert actual == expected

--- a/tests_cffi/test_sum.py
+++ b/tests_cffi/test_sum.py
@@ -1,0 +1,13 @@
+from tensora import BackendCompiler, Tensor, tensor_method
+
+
+def test_sum_non_adjacent():
+    b = Tensor.from_lol([1, 2, 3])
+    c = Tensor.from_lol([[1, 3, 5], [2, 4, 6]])
+    d = Tensor.from_lol([7, 8, 9])
+    function = tensor_method(
+        "a(i) = b(i) + c(j,i) + d(i)", formats={}, backend=BackendCompiler.cffi
+    )
+    actual = function(b=b, c=c, d=d)
+    expected = Tensor.from_lol([11, 17, 23])
+    assert actual == expected


### PR DESCRIPTION
A sum node is supposed to fuse loops of the same iteration variable. It has always done this when all the iteration variables were the same, but it [neglected](#56) to do this when only some of the iteration variables were the same. This PR ensures that sum nodes fuse all iteration nodes that they can.