### PR TITLE
Hoist declarations in LLVM

### DIFF
--- a/src/tensora/codegen/_hoist_declarations.py
+++ b/src/tensora/codegen/_hoist_declarations.py
@@ -1,0 +1,74 @@
+__all__ = ["hoist_declarations"]
+
+from functools import singledispatch
+
+from ..ir.ast import (
+    Assignment,
+    Block,
+    Branch,
+    Declaration,
+    DeclarationAssignment,
+    Expression,
+    FunctionDefinition,
+    Loop,
+    Return,
+    Statement,
+)
+from ..ir.types import Type
+
+
+@singledispatch
+def hoist_declarations_statement(self: Statement) -> dict[str, Type]:
+    raise NotImplementedError(
+        f"hoist_declarations_statement not implemented for {type(self).__name__}"
+    )
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_expression(self: Expression) -> dict[str, Type]:
+    return {}
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_declaration(self: Declaration) -> dict[str, Type]:
+    return {self.name.name: self.type}
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_assignment(self: Assignment) -> dict[str, Type]:
+    return {}
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_declaration_assignment(self: DeclarationAssignment) -> dict[str, Type]:
+    return {self.target.name.name: self.target.type}
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_block(self: Block) -> dict[str, Type]:
+    result = {}
+    for s in self.statements:
+        result.update(hoist_declarations_statement(s))
+    return result
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_branch(self: Branch) -> dict[str, Type]:
+    result = {}
+    result.update(hoist_declarations_statement(self.if_true))
+    result.update(hoist_declarations_statement(self.if_false))
+    return result
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_loop(self: Loop) -> dict[str, Type]:
+    return hoist_declarations_statement(self.body)
+
+
+@hoist_declarations_statement.register
+def hoist_declarations_return(self: Return) -> dict[str, Type]:
+    return {}
+
+
+def hoist_declarations(fn: FunctionDefinition) -> dict[str, Type]:
+    return hoist_declarations_statement(fn.body)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -64,6 +64,15 @@ def test_rhs():
     assert actual == expected
 
 
+def test_many_elements():
+    size = 1000000  # Big enough to trigger stack overflow
+
+    a = Tensor.from_dok({}, dimensions=(size,), format="d")
+    b = evaluate("b(i) = a(i)", "d", a=a)
+
+    assert b == Tensor.from_dok({}, dimensions=(size,), format="d")
+
+
 def test_multithread_evaluation():
     # As of version 1.14.4 of cffi, the FFI.compile method is not thread safe. This tests that evaluation of different
     # kernels is thread safe.


### PR DESCRIPTION
It turns out that if you do a local variable declaration inside a loop, the LLVM will allocate on the stack on every iteration. This leads to a segfault after about a million iterations of any kernel as the algorithm stack overflows. The solution is to hoist all declarations, which this PR does.