### PR TITLE
Fix realloc in LLVM

### DIFF
--- a/src/tensora/codegen/_ir_to_llvm.py
+++ b/src/tensora/codegen/_ir_to_llvm.py
@@ -377,7 +377,7 @@ def ir_to_llvm_array_allocate(
 def ir_to_llvm_array_reallocate(
     self: ArrayReallocate, builder: llvm.IRBuilder, locals: dict[str, llvm.Value]
 ) -> llvm.Value:
-    old_array_pointer = get_element_pointer(self.old, builder, locals)
+    old_array_pointer = ir_to_llvm_expression(self.old, builder, locals)
     old_memory_pointer = builder.bitcast(old_array_pointer, llvm.IntType(8).as_pointer())
     element_size = llvm.Constant(
         llvm_integer_type, type_to_llvm(self.element_type).get_abi_size(target_machine.target_data)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -64,13 +64,22 @@ def test_rhs():
     assert actual == expected
 
 
-def test_many_elements():
+def test_many_elements_stack_overflow():
     size = 1000000  # Big enough to trigger stack overflow
 
     a = Tensor.from_dok({}, dimensions=(size,), format="d")
     b = evaluate("b(i) = a(i)", "d", a=a)
 
     assert b == Tensor.from_dok({}, dimensions=(size,), format="d")
+
+
+def test_many_elements_realloc():
+    size = 2000000  # Big enough to trigger realloc
+
+    a = Tensor.from_dok({}, dimensions=(size,), format="d")
+    b = evaluate("b(i) = a(i)", "s", a=a)
+
+    assert b == Tensor.from_dok({}, dimensions=(size,), format="s")
 
 
 def test_multithread_evaluation():


### PR DESCRIPTION
Any problem large enough to trigger a realloc did not work in LLVM before. This ensures that the old pointer is properly handled as an r-value instead of an l-value.

Fixes #81.