### PR TITLE
Switch to uv build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling>=1.18.0"]
-build-backend = "hatchling.build"
+requires = ["uv_build == 0.8.*"]
+build-backend = "uv_build"
 
 [project]
 name = "tensora"


### PR DESCRIPTION
With the uv build backend is now out of experimental phase, we should depend on it directly instead of using Hatchling as an additional dependency.