### PR TITLE
Clarify documentation on mode ordering

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ Tensors are n-dimensional generalizations of matrices. Instead of being limited 
 
 Each dimension of a tensor has a size. This determines, conceptually, the number of elements in the tensor. "Conceptually" because the number of stored elements and the amount of memory required for the tensor may be smaller than that if the tensor is sparse.
 
-Tensors also have a format. The format has a list of modes, which determines the internal layout of the tensor, and a mode ordering, which maps each dimension to each mode. Each mode can be either sparse or dense. An example of two different formats with the same internal layout would be CSR, which has format `ds` in Tensora, and CSC, which has format `d1s0`.
+Tensors also have a format. The format has a list of modes, which determines the internal layout of the tensor, and a mode ordering, which maps each mode to each dimension. Each mode can be either sparse or dense. An example of two different formats with the same internal layout would be CSR, which has format `ds` in Tensora, and CSC, which has format `d1s0`.
 
 Here are a list of common formats:
 

--- a/docs/tensors.md
+++ b/docs/tensors.md
@@ -34,7 +34,11 @@ assert tensor.dimensions == (2, 3)
 
 ### `tensor.format`
 
-The type of `format` is a `tensora.Format` object, which has `modes` and `ordering` attributes. The `format.deparse()` method will give you a human-readable string.
+The `format` is a `tensora.Format` object, which has `modes` and `ordering` attributes.
+`modes` is a sequence of `Mode` enum members; either `dense` or `compressed`.
+`ordering` is a sequence of integers—the ith ordering means the ith mode is for that dimension.
+For example, a format `d2s0s1` means that the first mode is dense, and it is associated with the final dimension.
+The `format.deparse()` method will give you a human-readable string.
 
 ```python
 from tensora import Tensor


### PR DESCRIPTION
This was technically incorrect in `getting-started.md` and could be clarified further in `tensors.md`.