### PR TITLE
Skip iteration graphs that put contraction before sparse output

### DIFF
--- a/src/tensora/desugar/_to_iteration_graphs.py
+++ b/src/tensora/desugar/_to_iteration_graphs.py
@@ -217,6 +217,22 @@ def to_iteration_graphs_contract(
     yield from to_iteration_graphs_expression(self.expression, formats, counter)
 
 
+def target_has_pending_compressed(
+    target: ig.IterationGraph, output_layers: dict[str, TensorLayer]
+) -> bool:
+    """Whether any not-yet-placed output layer in the target chain is compressed.
+
+    A compressed output layer cannot be iterated after any contraction iteration. Iteration graphs
+    with such a structure must be rejected.
+    """
+    node = target
+    while isinstance(node, ig.IterationNode):
+        if output_layers[node.index_variable].mode == Mode.compressed:
+            return True
+        node = node.next
+    return False
+
+
 def merge_assignment(
     target: ig.IterationGraph, expression: ig.IterationGraph, output_layers: dict[str, TensorLayer]
 ) -> Iterator[ig.IterationGraph]:
@@ -238,7 +254,10 @@ def merge_assignment(
                     for tail in merge_assignment(target.next, expression, output_layers):
                         yield replace(target, output=output_leaf, next=tail)
 
-                if expression.index_variable not in target.next.later_indexes():
+                if (
+                    expression.index_variable not in target.next.later_indexes()
+                    and not target_has_pending_compressed(target, output_layers)
+                ):
                     for tail in merge_assignment(target, expression.next, output_layers):
                         yield replace(expression, next=tail)
         case (ig.IterationNode(), ig.SumNode(name=name, terms=terms)):

--- a/tests/assert_same_as_dense.py
+++ b/tests/assert_same_as_dense.py
@@ -1,0 +1,13 @@
+from tensora import Tensor, evaluate
+
+
+def assert_same_as_dense(expression, format_out, **tensor_pairs):
+    tensors_in_format = {
+        name: Tensor.from_lol(data, format=format) for name, (data, format) in tensor_pairs.items()
+    }
+    tensors_as_dense = {name: Tensor.from_lol(data) for name, (data, _) in tensor_pairs.items()}
+
+    dense_format = "d" * (format_out.count("d") + format_out.count("s"))
+    actual = evaluate(expression, format_out, **tensors_in_format)
+    expected = evaluate(expression, dense_format, **tensors_as_dense)
+    assert actual == expected

--- a/tests/test_combinatorically.py
+++ b/tests/test_combinatorically.py
@@ -2,17 +2,7 @@ import pytest
 
 from tensora import Tensor, evaluate
 
-
-def assert_same_as_dense(expression, format_out, **tensor_pairs):
-    tensors_in_format = {
-        name: Tensor.from_lol(data, format=format) for name, (data, format) in tensor_pairs.items()
-    }
-    tensors_as_dense = {name: Tensor.from_lol(data) for name, (data, _) in tensor_pairs.items()}
-
-    dense_format = "d" * (format_out.count("d") + format_out.count("s"))
-    actual = evaluate(expression, format_out, **tensors_in_format)
-    expected = evaluate(expression, dense_format, **tensors_as_dense)
-    assert actual == expected
+from .assert_same_as_dense import assert_same_as_dense
 
 
 @pytest.mark.parametrize("dense", [[3, 2, 4], [0, 0, 0]])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -3,6 +3,8 @@ from random import randrange
 
 from tensora import Tensor, evaluate
 
+from .assert_same_as_dense import assert_same_as_dense
+
 
 def test_csr_matrix_vector_product():
     A = Tensor.from_aos([(1, 0), (0, 1), (1, 2)], [2.0, -2.0, 4.0], dimensions=(2, 3), format="ds")
@@ -101,3 +103,17 @@ def test_multithread_evaluation():
 
     for actual in results:
         assert actual == expected
+
+
+def test_output_format_precludes_illegal_iteration_graphs():
+    # This test exercises the logic in merge_assignment to prevent the generation
+    # of iteration graphs where contraction iteration occurs before output
+    # iteration.
+    assert_same_as_dense(
+        "J(i,j) = S(i,r) * rdx(r,j) + S(i,r2) * rdu(r2,y) * udx(y,j)",
+        "ds",
+        S=([[1, 0, 2], [0, 3, 0]], "ds"),
+        rdx=([[1, 0], [0, 4], [5, 0]], "d1s0"),
+        rdu=([[0, 2], [1, 0], [0, 3]], "ds"),
+        udx=([[1, 0], [0, 6]], "d1s0"),
+    )


### PR DESCRIPTION
Fixes #53.

Ultimately, the issue was that `merge_assignment` was generating iteration graphs where sparse output layers were being iterated after contraction. This is not legal in the current design, but `best_algorithm` was picking one of them. Skipping these illegal graphs fixes the issue.