### PR TITLE
Determine sparse value write using a structural zeros flag

### DIFF
--- a/src/tensora/codegen/_ir_to_c.py
+++ b/src/tensora/codegen/_ir_to_c.py
@@ -71,6 +71,11 @@ def ir_to_c_array_index(self: ArrayIndex) -> str:
     return f"{ir_to_c_expression(self.target)}[{ir_to_c_expression(self.index)}]"
 
 
+@ir_to_c_expression.register(BooleanLiteral)
+def ir_to_c_boolean_literal(self: BooleanLiteral) -> str:
+    return "true" if self.value else "false"
+
+
 @ir_to_c_expression.register(IntegerLiteral)
 def ir_to_c_integer_literal(self: IntegerLiteral) -> str:
     return str(self.value)
@@ -79,11 +84,6 @@ def ir_to_c_integer_literal(self: IntegerLiteral) -> str:
 @ir_to_c_expression.register(FloatLiteral)
 def ir_to_c_float_literal(self: FloatLiteral) -> str:
     return str(self.value)
-
-
-@ir_to_c_expression.register(BooleanLiteral)
-def ir_to_c_boolean_literal(self: BooleanLiteral) -> str:
-    return str(int(self.value))
 
 
 @ir_to_c_expression.register(Add)

--- a/src/tensora/codegen/_type_to_c.py
+++ b/src/tensora/codegen/_type_to_c.py
@@ -2,7 +2,7 @@ __all__ = ["type_to_c"]
 
 from functools import singledispatch
 
-from ..ir.types import Array, FixedArray, Float, Integer, Mode, Pointer, Tensor, Type
+from ..ir.types import Array, Boolean, FixedArray, Float, Integer, Mode, Pointer, Tensor, Type
 
 
 def space_variable(variable: str | None = None) -> str:
@@ -15,6 +15,11 @@ def space_variable(variable: str | None = None) -> str:
 @singledispatch
 def type_to_c(self: Type, variable: str | None = None) -> str:
     raise NotImplementedError(f"type_to_c not implemented for {type(self)}: {self}")
+
+
+@type_to_c.register(Boolean)
+def type_to_c_boolean(self: Boolean, variable: str | None = None) -> str:
+    return "bool" + space_variable(variable)
 
 
 @type_to_c.register(Integer)

--- a/src/tensora/codegen/_type_to_llvm.py
+++ b/src/tensora/codegen/_type_to_llvm.py
@@ -12,7 +12,7 @@ from functools import singledispatch
 
 import llvmlite.ir as llvm
 
-from ..ir.types import Array, FixedArray, Float, Integer, Mode, Pointer, Tensor, Type
+from ..ir.types import Array, Boolean, FixedArray, Float, Integer, Mode, Pointer, Tensor, Type
 
 llvm_integer_type = llvm.IntType(32)
 llvm_float_type = llvm.DoubleType()
@@ -24,6 +24,11 @@ llvm_size_type = llvm.IntType(64)
 @singledispatch
 def type_to_llvm(self: Type) -> llvm.Type:
     raise NotImplementedError(f"type_to_llvm not implemented for {type(self)}: {self}")
+
+
+@type_to_llvm.register(Boolean)
+def type_to_llvm_boolean(self: Boolean) -> llvm.Type:
+    return llvm_boolean_type
 
 
 @type_to_llvm.register(Integer)

--- a/src/tensora/compile/_compile_cffi.py
+++ b/src/tensora/compile/_compile_cffi.py
@@ -11,7 +11,9 @@ from ._cffi_ownership import taco_type_header, tensor_cdefs
 
 lock = threading.Lock()
 
+# stdbool.h is required until all compilers support C23
 taco_define_header = """
+    #include <stdbool.h>
     #ifndef TACO_C_HEADERS
     #define TACO_C_HEADERS
     #define TACO_MIN(_a,_b) ((_a) < (_b) ? (_a) : (_b))

--- a/src/tensora/ir/ast.py
+++ b/src/tensora/ir/ast.py
@@ -44,14 +44,17 @@ from typing import Sequence
 from .types import Type
 
 
-def to_expression(expression: Expression | float | int | str) -> Expression:
+def to_expression(expression: Expression | bool | int | float | str) -> Expression:
     match expression:
         case Expression():
             return expression
-        case float():
-            return FloatLiteral(expression)
+        case bool():
+            # bool is a subclass of int, so this must precede the int case
+            return BooleanLiteral(expression)
         case int():
             return IntegerLiteral(expression)
+        case float():
+            return FloatLiteral(expression)
         case str():
             return Variable(expression)
 

--- a/src/tensora/ir/types.py
+++ b/src/tensora/ir/types.py
@@ -1,5 +1,6 @@
 __all__ = [
     "Array",
+    "Boolean",
     "FixedArray",
     "Float",
     "Integer",
@@ -7,6 +8,7 @@ __all__ = [
     "Pointer",
     "Tensor",
     "Type",
+    "boolean",
     "float",
     "integer",
     "mode",
@@ -18,6 +20,14 @@ from dataclasses import dataclass
 
 class Type:
     __slots__ = ()
+
+
+@dataclass(frozen=True, slots=True)
+class Boolean(Type):
+    pass
+
+
+boolean = Boolean()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -32,6 +32,7 @@ from ._write_sparse_ir import (
 )
 from .identifiable_expression import to_ir
 from .identifiable_expression._tensor_layer import TensorLayer
+from .identifiable_expression.ast import Integer
 from .iteration_graph import IterationGraph, IterationNode, SumNode, TerminalNode
 from .outputs import AppendOutput, Output
 
@@ -49,11 +50,15 @@ def to_ir_iteration_graph(
 def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Computation of expression ***")
 
-    # Record that a contribution reached the terminal for each enclosing sparse output layer.
-    # This is structural (independent of the value), so it is emitted in every kernel type,
-    # allowing assemble and compute to agree on which coordinates are stored.
-    for flag in output.written_flags():
-        source.append(flag.assign(True))
+    # Record that a value was written by the terminal for each enclosing sparse output layer.
+    # This is structural (independent of the computed value), so it is emitted in every kernel
+    # type, allowing assemble and compute to agree on which coordinates are stored. A terminal
+    # whose expression has exhausted to zero (e.g. a dense output layer's structural fill where a sparse
+    # factor is absent) is not a real contribution, so it must not set the flag; otherwise it would
+    # make an enclosing sparse output layer store an all-zero region.
+    if self.expression != Integer(0):
+        for flag in output.written_flags():
+            source.append(flag.assign(True))
 
     if kernel_type.is_compute():
         source.append(output.write_assignment(to_ir(self.expression), kernel_type))

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -18,7 +18,6 @@ from ..ir.ast import (
     IntegerLiteral,
     LessThan,
     Min,
-    NotEqual,
     Return,
     Variable,
 )
@@ -54,7 +53,7 @@ def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: K
     # This is structural (independent of the value), so it is emitted in every kernel type,
     # allowing assemble and compute to agree on which coordinates are stored.
     for flag in output.written_flags():
-        source.append(flag.assign(1))
+        source.append(flag.assign(True))
 
     if kernel_type.is_compute():
         source.append(output.write_assignment(to_ir(self.expression), kernel_type))
@@ -98,7 +97,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
         # If not doing compute and no assembly is left, return early. This optimization avoids
         # generating unecessary looping that would make the code look bad (because the peephole
         # optimizer won't remove it) but wouldn't affect performance (because the backend compiler
-        # would remove it). The exception is when a gating flag is active: this subtree gates an
+        # would remove it). The exception is when a written flag is active: this subtree gates an
         # enclosing sparse output's crd append, so its structure must run even in the assemble
         # kernel to compute the flag.
         return source
@@ -120,9 +119,9 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
     # Gate its crd append on a flag that the terminal sets whenever a contribution reaches it. The
     # terminal recovers this flag's name from the output format, so nothing needs to be threaded
     # down; it works no matter how many sparse or dense layers lie between this one and the value.
-    gating_flag: Variable | None = None
+    written_flag: Variable | None = None
     if self.is_sparse_output() and isinstance(next_output, AppendOutput):
-        gating_flag = value_written_name(self.output.tensor.id, self.output.layer)
+        written_flag = value_written_name(self.output.tensor.id, self.output.layer)
 
     ##################
     # Initialization #
@@ -319,8 +318,8 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 # sets it back to one if any contribution reaches it, at which point this layer
                 # knows it must store this coordinate. This is reset per iteration of this output
                 # coordinate.
-                if gating_flag is not None:
-                    block.append(gating_flag.declare(types.integer).assign(0))
+                if written_flag is not None:
+                    block.append(written_flag.declare(types.boolean).assign(False))
 
                 #####################
                 # Invoke next layer #
@@ -336,7 +335,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 # output layer, so this decision is identical across assemble and compute and needs
                 # no cross-talk between layers.
                 if self.is_sparse_output() and isinstance(next_output, AppendOutput):
-                    with block.branch(NotEqual(gating_flag, IntegerLiteral(0))):
+                    with block.branch(written_flag):
                         if kernel_type.is_assemble():
                             block.append(write_crd_assembly(self.output))
                         block.append(self.output.layer_pointer().increment())
@@ -387,7 +386,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
 def to_ir_sum(self: SumNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Sum ***")
 
-    # A Sum node emits its terms during compute (to accumulate values), and also when a gating
+    # A Sum node emits its terms during compute (to accumulate values), and also when a written
     # flag is active: the assemble kernel must run the terms' structural skeleton so it can set
     # the flag and decide whether the enclosing sparse output stores this coordinate. The value
     # work (bucket zero-init and accumulation) is suppressed outside of compute, so this shared

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -49,7 +49,7 @@ def to_ir_iteration_graph(
 def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Computation of expression ***")
 
-    # Record that a contribution reached the terminal for each enclosing compressed output layer.
+    # Record that a contribution reached the terminal for each enclosing sparse output layer.
     # This is structural (independent of the value), so it is emitted in every kernel type,
     # allowing assemble and compute to agree on which coordinates are stored.
     for flag in output.written_flags():
@@ -93,13 +93,11 @@ def generate_subgraphs(graph: IterationNode) -> list[IterationNode]:
 def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder(f"*** Iteration over {self.index_variable} ***")
 
-    if not kernel_type.is_compute() and not self.has_assemble() and not output.has_active_flags():
-        # If not doing compute and no assembly is left, return early. This optimization avoids
-        # generating unecessary looping that would make the code look bad (because the peephole
-        # optimizer won't remove it) but wouldn't affect performance (because the backend compiler
-        # would remove it). The exception is when a written flag is active: this subtree gates an
-        # enclosing sparse output's crd append, so its structure must run even in the assemble
-        # kernel to compute the flag.
+    if not kernel_type.is_compute() and not output.has_sparse_layer():
+        # A fully dense output has no assemble code to emit, so skip the iteration entirely. This
+        # avoids generating unnecessary looping that would make the code look bad and in a way that
+        # the peephole optimizer won't remove. A dead-code elimination pass could eliminate the
+        # need for this early return.
         return source
 
     loop_variable = Variable(self.index_variable)
@@ -116,11 +114,8 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
     source.append(next_output_declarations)
 
     # A sparse output layer stores a coordinate only if a value is written somewhere below it.
-    # Gate its crd append on a flag that the terminal sets whenever a contribution reaches it. The
-    # terminal recovers this flag's name from the output format, so nothing needs to be threaded
-    # down; it works no matter how many sparse or dense layers lie between this one and the value.
-    written_flag: Variable | None = None
-    if self.is_sparse_output() and isinstance(next_output, AppendOutput):
+    # Gate its append on a flag that a terminal expression sets whenever a contribution reaches it.
+    if self.is_sparse_output():
         written_flag = written_name(self.output.tensor.name, self.output.layer)
 
     ##################
@@ -157,11 +152,10 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
             # 2. The input is sparse, but the output is dense, so we finish the loop, writing zeros
             #    to the dense layer.
             # 3. The input is dense, but the output is sparse, so we finish the loop, storing the
-            #    coordinate only where a value was contributed (gated by the value-written flag
-            #    below) rather than an explicit zero.
+            #    coordinate only when a value was written (gated by the written flag).
             # 4. The input and output are both sparse, so we skip the implicit zero entirely.
             #
-            # This last case is handled by this if statement. Because it is guarenteed to the be
+            # This last case is handled by this if statement. Because it is guaranteed to the be
             # the last subnode, break or continue would do the same thing.
             continue
 
@@ -278,8 +272,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                     # 1. The input and output are both and dense, so we write the value.
                     # 2. The input is sparse, but the output is dense, so we write a zero.
                     # 3. The input is dense, but the output is sparse, so we store the coordinate
-                    #    only where a value was contributed (gated by the value-written flag)
-                    #    rather than an explicit zero.
+                    #    only where a value was written.
                     # 4. The input and output are both sparse, so we write nothing.
                     #
                     # Like above, this is necessarily the last subsubnode, so break or continue
@@ -304,11 +297,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 ###################################
                 # This is done at this level, rather than up a level, because none of the
                 # subsubnode conditions may hit. In that case, no allocation should be done.
-                if (
-                    kernel_type.is_assemble()
-                    and self.is_sparse_output()
-                    and isinstance(next_output, AppendOutput)
-                ):
+                if kernel_type.is_assemble() and self.is_sparse_output():
                     block.append(write_pos_allocation(self.output))
 
                 ############################
@@ -318,7 +307,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 # sets it back to one if any contribution reaches it, at which point this layer
                 # knows it must store this coordinate. This is reset per iteration of this output
                 # coordinate.
-                if written_flag is not None:
+                if self.is_sparse_output():
                     block.append(written_flag.declare(types.boolean).assign(False))
 
                 #####################
@@ -331,10 +320,9 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 ########################################################
                 # Only advance the index for this sparse layer if a value was written into this
                 # output coordinate. Otherwise the coordinate is an implicit zero and must not be
-                # stored. The flag is set structurally at the terminal for every enclosing sparse
-                # output layer, so this decision is identical across assemble and compute and needs
-                # no cross-talk between layers.
-                if self.is_sparse_output() and isinstance(next_output, AppendOutput):
+                # stored. The flag is set structurally at the terminal expression for every
+                # enclosing sparse output layer.
+                if self.is_sparse_output():
                     with block.branch(written_flag):
                         if kernel_type.is_assemble():
                             block.append(write_crd_assembly(self.output))
@@ -370,11 +358,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
     ################################
     # Write sparse output position #
     ################################
-    if (
-        kernel_type.is_assemble()
-        and self.is_sparse_output()
-        and isinstance(next_output, AppendOutput)
-    ):
+    if kernel_type.is_assemble() and self.is_sparse_output():
         source.append(write_pos_assembly(self.output))
 
     source.append(next_output_cleanup)
@@ -386,13 +370,10 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
 def to_ir_sum(self: SumNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Sum ***")
 
-    # A Sum node emits its terms during compute (to accumulate values), and also when a written
-    # flag is active: the assemble kernel must run the terms' structural skeleton so it can set
-    # the flag and decide whether the enclosing sparse output stores this coordinate. The value
-    # work (bucket zero-init and accumulation) is suppressed outside of compute, so this shared
-    # traversal is purely structural in the assemble kernel.
-    if kernel_type.is_compute() or output.has_active_flags():
-        # No assembly is currently allowed downstream of a Sum node
+    if kernel_type.is_compute() or output.has_sparse_layer():
+        # Like in the iteration node, a fully dense output has no assemble code to emit, so skip
+        # the declaration entirely. A dead-code elimination pass could eliminate the need for this
+        # guard.
         next_output, next_output_declarations, _ = output.next_output(None, kernel_type)
         source.append(next_output_declarations)
 

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -53,9 +53,9 @@ def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: K
     # Record that a value was written by the terminal for each enclosing sparse output layer.
     # This is structural (independent of the computed value), so it is emitted in every kernel
     # type, allowing assemble and compute to agree on which coordinates are stored. A terminal
-    # whose expression has exhausted to zero (e.g. a dense output layer's structural fill where a sparse
-    # factor is absent) is not a real contribution, so it must not set the flag; otherwise it would
-    # make an enclosing sparse output layer store an all-zero region.
+    # whose expression has exhausted to zero (e.g. a dense output layer's structural fill where a
+    # sparse factor is absent) is not a real contribution, so it must not set the flag; otherwise
+    # it would make an enclosing sparse output layer store an all-zero region.
     if self.expression != Integer(0):
         for flag in output.written_flags():
             source.append(flag.assign(True))
@@ -305,11 +305,11 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 if kernel_type.is_assemble() and self.is_sparse_output():
                     block.append(write_pos_allocation(self.output))
 
-                ############################
+                ###########################
                 # Reset this layer's flag #
-                ############################
-                # Reset the "value written" flag to zero before the subtree runs. The terminal
-                # sets it back to one if any contribution reaches it, at which point this layer
+                ###########################
+                # Reset the "value written" flag to false before the subtree runs. The terminal
+                # sets it back to true if any contribution reaches it, at which point this layer
                 # knows it must store this coordinate. This is reset per iteration of this output
                 # coordinate.
                 if self.is_sparse_output():

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -23,7 +23,7 @@ from ..ir.ast import (
 )
 from ..kernel_type import KernelType
 from ._definition import Definition
-from ._names import crd_name, dimension_name, pos_name, vals_name, value_written_name
+from ._names import crd_name, dimension_name, pos_name, vals_name, written_name
 from ._write_sparse_ir import (
     write_crd_assembly,
     write_pos_allocation,
@@ -121,7 +121,7 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
     # down; it works no matter how many sparse or dense layers lie between this one and the value.
     written_flag: Variable | None = None
     if self.is_sparse_output() and isinstance(next_output, AppendOutput):
-        written_flag = value_written_name(self.output.tensor.id, self.output.layer)
+        written_flag = written_name(self.output.tensor.name, self.output.layer)
 
     ##################
     # Initialization #

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -15,7 +15,6 @@ from ..ir.ast import (
     Equal,
     Expression,
     FunctionDefinition,
-    GreaterThan,
     IntegerLiteral,
     LessThan,
     Min,
@@ -51,10 +50,10 @@ def to_ir_iteration_graph(
 def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Computation of expression ***")
 
-    # Record that a contribution reached the terminal for this output coordinate. This is
-    # structural (independent of the value), so it is emitted in every kernel type, allowing
-    # assemble and compute to agree on which coordinates are stored.
-    for flag in output.gating_flags:
+    # Record that a contribution reached the terminal for each enclosing compressed output layer.
+    # This is structural (independent of the value), so it is emitted in every kernel type,
+    # allowing assemble and compute to agree on which coordinates are stored.
+    for flag in output.written_flags():
         source.append(flag.assign(1))
 
     if kernel_type.is_compute():
@@ -117,18 +116,13 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
     )
     source.append(next_output_declarations)
 
-    # If this is a sparse output layer whose next layer is not itself a sparse output (the "else"
-    # case below), its crd append cannot rely on the next sparse layer's pointer to know whether
-    # anything was written. Instead, gate the append on a flag set at the terminal whenever a
-    # contribution reaches it. The flag is threaded down to the terminal via the output.
+    # A sparse output layer stores a coordinate only if a value is written somewhere below it.
+    # Gate its crd append on a flag that the terminal sets whenever a contribution reaches it. The
+    # terminal recovers this flag's name from the output format, so nothing needs to be threaded
+    # down; it works no matter how many sparse or dense layers lie between this one and the value.
     gating_flag: Variable | None = None
-    if (
-        self.is_sparse_output()
-        and not self.next.is_sparse_output()
-        and isinstance(next_output, AppendOutput)
-    ):
+    if self.is_sparse_output() and isinstance(next_output, AppendOutput):
         gating_flag = value_written_name(self.output.tensor.id, self.output.layer)
-        next_output = next_output.with_flag(gating_flag)
 
     ##################
     # Initialization #
@@ -318,30 +312,13 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 ):
                     block.append(write_pos_allocation(self.output))
 
-                ################################
-                # Store position of next layer #
-                ################################
-                # This allows the current sparse layer to remember if the next sparse layer had any
-                # nonzeros. This is conceptually part of the next layer, but it is used by this
-                # layer's crd assembly, so we put it here. We could constitutively have each layer
-                # store a bool indicating whether or not it wrote anything, which woould be
-                # optimized out when either layer was not sparse, but the upper layer would still
-                # need to probe the lower layer, so not that much would be gained.
-                if self.is_sparse_output() and self.next.is_sparse_output():
-                    with block.block("Save next layer's position"):
-                        next_output_layer: TensorLayer = self.next.output
-                        next_pointer = next_output_layer.layer_pointer()
-                        next_pointer_begin = next_output_layer.layer_begin_name().declare(
-                            types.integer
-                        )
-                        block.append(next_pointer_begin.assign(next_pointer))
-
-                ##############################
+                ############################
                 # Reset this layer's flag #
-                ##############################
+                ############################
                 # Reset the "value written" flag to zero before the subtree runs. The terminal
-                # sets it back to one if any contribution reaches it. This is reset per iteration
-                # of this output coordinate.
+                # sets it back to one if any contribution reaches it, at which point this layer
+                # knows it must store this coordinate. This is reset per iteration of this output
+                # coordinate.
                 if gating_flag is not None:
                     block.append(gating_flag.declare(types.integer).assign(0))
 
@@ -353,25 +330,16 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                 ########################################################
                 # Write sparse output index and advance output pointer #
                 ########################################################
+                # Only advance the index for this sparse layer if a value was written into this
+                # output coordinate. Otherwise the coordinate is an implicit zero and must not be
+                # stored. The flag is set structurally at the terminal for every enclosing sparse
+                # output layer, so this decision is identical across assemble and compute and needs
+                # no cross-talk between layers.
                 if self.is_sparse_output() and isinstance(next_output, AppendOutput):
-                    if self.next.is_sparse_output():
-                        # Only advance the index for this sparse layer if the next sparse layer
-                        # had any nonzeros.
-                        next_output_layer: TensorLayer = self.next.output
-                        next_pointer = next_output_layer.layer_pointer()
-                        next_pointer_begin = next_output_layer.layer_begin_name()
-                        with block.branch(GreaterThan(next_pointer, next_pointer_begin)):
-                            if kernel_type.is_assemble():
-                                block.append(write_crd_assembly(self.output))
-                            block.append(self.output.layer_pointer().increment())
-                    else:
-                        # Only advance the index for this sparse layer if a value was written into
-                        # this output coordinate. Otherwise the coordinate is an implicit zero and
-                        # must not be stored. The gate is structural, so assemble and compute agree.
-                        with block.branch(NotEqual(gating_flag, IntegerLiteral(0))):
-                            if kernel_type.is_assemble():
-                                block.append(write_crd_assembly(self.output))
-                            block.append(self.output.layer_pointer().increment())
+                    with block.branch(NotEqual(gating_flag, IntegerLiteral(0))):
+                        if kernel_type.is_assemble():
+                            block.append(write_crd_assembly(self.output))
+                        block.append(self.output.layer_pointer().increment())
 
                 subsubnode_leaves.append((condition, block.finalize()))
 

--- a/src/tensora/iteration_graph/_generate_ir.py
+++ b/src/tensora/iteration_graph/_generate_ir.py
@@ -19,12 +19,13 @@ from ..ir.ast import (
     IntegerLiteral,
     LessThan,
     Min,
+    NotEqual,
     Return,
     Variable,
 )
 from ..kernel_type import KernelType
 from ._definition import Definition
-from ._names import crd_name, dimension_name, pos_name, vals_name
+from ._names import crd_name, dimension_name, pos_name, vals_name, value_written_name
 from ._write_sparse_ir import (
     write_crd_assembly,
     write_pos_allocation,
@@ -49,6 +50,12 @@ def to_ir_iteration_graph(
 @to_ir_iteration_graph.register(TerminalNode)
 def to_ir_terminal_expression(self: TerminalNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Computation of expression ***")
+
+    # Record that a contribution reached the terminal for this output coordinate. This is
+    # structural (independent of the value), so it is emitted in every kernel type, allowing
+    # assemble and compute to agree on which coordinates are stored.
+    for flag in output.gating_flags:
+        source.append(flag.assign(1))
 
     if kernel_type.is_compute():
         source.append(output.write_assignment(to_ir(self.expression), kernel_type))
@@ -88,11 +95,13 @@ def generate_subgraphs(graph: IterationNode) -> list[IterationNode]:
 def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder(f"*** Iteration over {self.index_variable} ***")
 
-    if not kernel_type.is_compute() and not self.has_assemble():
+    if not kernel_type.is_compute() and not self.has_assemble() and not output.has_active_flags():
         # If not doing compute and no assembly is left, return early. This optimization avoids
         # generating unecessary looping that would make the code look bad (because the peephole
         # optimizer won't remove it) but wouldn't affect performance (because the backend compiler
-        # would remove it).
+        # would remove it). The exception is when a gating flag is active: this subtree gates an
+        # enclosing sparse output's crd append, so its structure must run even in the assemble
+        # kernel to compute the flag.
         return source
 
     loop_variable = Variable(self.index_variable)
@@ -107,6 +116,19 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
         self.output, kernel_type
     )
     source.append(next_output_declarations)
+
+    # If this is a sparse output layer whose next layer is not itself a sparse output (the "else"
+    # case below), its crd append cannot rely on the next sparse layer's pointer to know whether
+    # anything was written. Instead, gate the append on a flag set at the terminal whenever a
+    # contribution reaches it. The flag is threaded down to the terminal via the output.
+    gating_flag: Variable | None = None
+    if (
+        self.is_sparse_output()
+        and not self.next.is_sparse_output()
+        and isinstance(next_output, AppendOutput)
+    ):
+        gating_flag = value_written_name(self.output.tensor.id, self.output.layer)
+        next_output = next_output.with_flag(gating_flag)
 
     ##################
     # Initialization #
@@ -141,8 +163,9 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
             # 1. The input and output are both and dense, so we simply finish the loop.
             # 2. The input is sparse, but the output is dense, so we finish the loop, writing zeros
             #    to the dense layer.
-            # 3. The input is dense, but the output is sparse, so we finish the loop, writing
-            #    explicit zeros to the sparse layer.
+            # 3. The input is dense, but the output is sparse, so we finish the loop, storing the
+            #    coordinate only where a value was contributed (gated by the value-written flag
+            #    below) rather than an explicit zero.
             # 4. The input and output are both sparse, so we skip the implicit zero entirely.
             #
             # This last case is handled by this if statement. Because it is guarenteed to the be
@@ -261,8 +284,9 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                     # the same four situations as for subnodes above:
                     # 1. The input and output are both and dense, so we write the value.
                     # 2. The input is sparse, but the output is dense, so we write a zero.
-                    # 3. The input is dense, but the output is sparse, so we write an explicit
-                    #    zero to the sparse layer.
+                    # 3. The input is dense, but the output is sparse, so we store the coordinate
+                    #    only where a value was contributed (gated by the value-written flag)
+                    #    rather than an explicit zero.
                     # 4. The input and output are both sparse, so we write nothing.
                     #
                     # Like above, this is necessarily the last subsubnode, so break or continue
@@ -312,6 +336,15 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                         )
                         block.append(next_pointer_begin.assign(next_pointer))
 
+                ##############################
+                # Reset this layer's flag #
+                ##############################
+                # Reset the "value written" flag to zero before the subtree runs. The terminal
+                # sets it back to one if any contribution reaches it. This is reset per iteration
+                # of this output coordinate.
+                if gating_flag is not None:
+                    block.append(gating_flag.declare(types.integer).assign(0))
+
                 #####################
                 # Invoke next layer #
                 #####################
@@ -332,9 +365,13 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
                                 block.append(write_crd_assembly(self.output))
                             block.append(self.output.layer_pointer().increment())
                     else:
-                        if kernel_type.is_assemble():
-                            block.append(write_crd_assembly(self.output))
-                        block.append(self.output.layer_pointer().increment())
+                        # Only advance the index for this sparse layer if a value was written into
+                        # this output coordinate. Otherwise the coordinate is an implicit zero and
+                        # must not be stored. The gate is structural, so assemble and compute agree.
+                        with block.branch(NotEqual(gating_flag, IntegerLiteral(0))):
+                            if kernel_type.is_assemble():
+                                block.append(write_crd_assembly(self.output))
+                            block.append(self.output.layer_pointer().increment())
 
                 subsubnode_leaves.append((condition, block.finalize()))
 
@@ -382,7 +419,12 @@ def to_ir_iteration_variable(self: IterationNode, output: Output, kernel_type: K
 def to_ir_sum(self: SumNode, output: Output, kernel_type: KernelType):
     source = SourceBuilder("*** Sum ***")
 
-    if kernel_type.is_compute():
+    # A Sum node emits its terms during compute (to accumulate values), and also when a gating
+    # flag is active: the assemble kernel must run the terms' structural skeleton so it can set
+    # the flag and decide whether the enclosing sparse output stores this coordinate. The value
+    # work (bucket zero-init and accumulation) is suppressed outside of compute, so this shared
+    # traversal is purely structural in the assemble kernel.
+    if kernel_type.is_compute() or output.has_active_flags():
         # No assembly is currently allowed downstream of a Sum node
         next_output, next_output_declarations, _ = output.next_output(None, kernel_type)
         source.append(next_output_declarations)

--- a/src/tensora/iteration_graph/_names.py
+++ b/src/tensora/iteration_graph/_names.py
@@ -12,7 +12,7 @@ __all__ = [
     "vals_capacity_name",
     "vals_name",
     "value_from_crd",
-    "value_written_name",
+    "written_name",
 ]
 
 
@@ -66,5 +66,5 @@ def value_from_crd(reference: str, layer: int) -> Variable:
     return Variable(f"i_{reference}_{layer}")
 
 
-def value_written_name(reference: str, layer: int) -> Variable:
-    return Variable(f"written_{reference}_{layer}")
+def written_name(tensor: str, layer: int) -> Variable:
+    return Variable(f"written_{tensor}_{layer}")

--- a/src/tensora/iteration_graph/_names.py
+++ b/src/tensora/iteration_graph/_names.py
@@ -62,10 +62,6 @@ def sparse_end_name(reference: str, layer: int) -> Variable:
     return Variable(f"p_{reference}_{layer}_end")
 
 
-def layer_begin_name(reference: str, layer: int) -> Variable:
-    return Variable(f"p_{reference}_{layer}_begin")
-
-
 def value_from_crd(reference: str, layer: int) -> Variable:
     return Variable(f"i_{reference}_{layer}")
 

--- a/src/tensora/iteration_graph/_names.py
+++ b/src/tensora/iteration_graph/_names.py
@@ -12,6 +12,7 @@ __all__ = [
     "vals_capacity_name",
     "vals_name",
     "value_from_crd",
+    "value_written_name",
 ]
 
 
@@ -67,3 +68,7 @@ def layer_begin_name(reference: str, layer: int) -> Variable:
 
 def value_from_crd(reference: str, layer: int) -> Variable:
     return Variable(f"i_{reference}_{layer}")
+
+
+def value_written_name(reference: str, layer: int) -> Variable:
+    return Variable(f"written_{reference}_{layer}")

--- a/src/tensora/iteration_graph/identifiable_expression/_extract_context.py
+++ b/src/tensora/iteration_graph/identifiable_expression/_extract_context.py
@@ -16,7 +16,6 @@ class Context:
     sparse_leaves: list[TensorLayer] = field(default_factory=list)
     dense_leaves: list[TensorLayer] = field(default_factory=list)
     indexes: frozenset[str] = frozenset()
-    has_assemble: bool = False
 
     def add(self, other: Context) -> Context:
         return Context(
@@ -24,7 +23,6 @@ class Context:
             sparse_leaves=self.sparse_leaves + other.sparse_leaves,
             dense_leaves=self.dense_leaves + other.dense_leaves,
             indexes=self.indexes | other.indexes,
-            has_assemble=self.has_assemble or other.has_assemble,
         )
 
     def multiply(self, other: Context) -> Context:
@@ -33,7 +31,6 @@ class Context:
             sparse_leaves=self.sparse_leaves + other.sparse_leaves,
             dense_leaves=self.dense_leaves + other.dense_leaves,
             indexes=self.indexes | other.indexes,
-            has_assemble=self.has_assemble or other.has_assemble,
         )
 
 

--- a/src/tensora/iteration_graph/identifiable_expression/_tensor_layer.py
+++ b/src/tensora/iteration_graph/identifiable_expression/_tensor_layer.py
@@ -6,7 +6,6 @@ from ...ir import ast as ir
 from .._names import (
     crd_capacity_name,
     crd_name,
-    layer_begin_name,
     layer_pointer,
     pos_capacity_name,
     pos_name,
@@ -54,9 +53,6 @@ class TensorLayer:
 
     def sparse_end_name(self) -> ir.Variable:
         return sparse_end_name(self.tensor.id, self.layer)
-
-    def layer_begin_name(self) -> ir.Variable:
-        return layer_begin_name(self.tensor.id, self.layer)
 
     def value_from_crd(self) -> ir.Variable:
         return value_from_crd(self.tensor.id, self.layer)

--- a/src/tensora/iteration_graph/iteration_graph.py
+++ b/src/tensora/iteration_graph/iteration_graph.py
@@ -69,9 +69,7 @@ class IterationNode(IterationGraph):
     def extract_context(self, index: str) -> Context:
         next_context = self.next.extract_context(index)
         return replace(
-            next_context,
-            indexes=next_context.indexes | frozenset([self.index_variable]),
-            has_assemble=next_context.has_assemble or self.is_sparse_output(),
+            next_context, indexes=next_context.indexes | frozenset([self.index_variable])
         )
 
     def exhaust_tensor(self, reference: str) -> IterationGraph:
@@ -96,9 +94,6 @@ class IterationNode(IterationGraph):
 
     def later_indexes(self) -> frozenset[str]:
         return self.context.indexes
-
-    def has_assemble(self) -> bool:
-        return self.context.has_assemble
 
 
 @dataclass(frozen=True)

--- a/src/tensora/iteration_graph/outputs/_append.py
+++ b/src/tensora/iteration_graph/outputs/_append.py
@@ -29,7 +29,6 @@ default_array_size = Multiply(IntegerLiteral(1024), IntegerLiteral(1024))
 class AppendOutput(Output):
     output: ie_ast.Tensor
     next_layer: int
-    gating_flags: tuple[Variable, ...] = ()
 
     def vals_pointer(self) -> Expression:
         return previous_layer_pointer(self.output.id, self.output.order)
@@ -131,11 +130,7 @@ class AppendOutput(Output):
         self, iteration_output: TensorLayer | None, kernel_type: KernelType
     ) -> tuple[Output, SourceBuilder, SourceBuilder]:
         if iteration_output is not None and self.next_layer == iteration_output.layer:
-            return (
-                AppendOutput(self.output, self.next_layer + 1, self.gating_flags),
-                SourceBuilder(),
-                SourceBuilder(),
-            )
+            return AppendOutput(self.output, self.next_layer + 1), SourceBuilder(), SourceBuilder()
         else:
             # No layer or wrong layer was encountered
             dense_only_remaining = all(
@@ -143,9 +138,7 @@ class AppendOutput(Output):
             )
             if dense_only_remaining:
                 next_output = BucketOutput(
-                    self.output,
-                    list(range(self.next_layer, len(self.output.modes))),
-                    gating_flags=self.gating_flags,
+                    self.output, list(range(self.next_layer, len(self.output.modes)))
                 )
                 dimension_names = [
                     dimension_name(index) for index in self.output.indexes[self.next_layer :]

--- a/src/tensora/iteration_graph/outputs/_append.py
+++ b/src/tensora/iteration_graph/outputs/_append.py
@@ -29,6 +29,7 @@ default_array_size = Multiply(IntegerLiteral(1024), IntegerLiteral(1024))
 class AppendOutput(Output):
     output: ie_ast.Tensor
     next_layer: int
+    gating_flags: tuple[Variable, ...] = ()
 
     def vals_pointer(self) -> Expression:
         return previous_layer_pointer(self.output.id, self.output.order)
@@ -130,7 +131,11 @@ class AppendOutput(Output):
         self, iteration_output: TensorLayer | None, kernel_type: KernelType
     ) -> tuple[Output, SourceBuilder, SourceBuilder]:
         if iteration_output is not None and self.next_layer == iteration_output.layer:
-            return AppendOutput(self.output, self.next_layer + 1), SourceBuilder(), SourceBuilder()
+            return (
+                AppendOutput(self.output, self.next_layer + 1, self.gating_flags),
+                SourceBuilder(),
+                SourceBuilder(),
+            )
         else:
             # No layer or wrong layer was encountered
             dense_only_remaining = all(
@@ -138,7 +143,9 @@ class AppendOutput(Output):
             )
             if dense_only_remaining:
                 next_output = BucketOutput(
-                    self.output, list(range(self.next_layer, len(self.output.modes)))
+                    self.output,
+                    list(range(self.next_layer, len(self.output.modes))),
+                    gating_flags=self.gating_flags,
                 )
                 dimension_names = [
                     dimension_name(index) for index in self.output.indexes[self.next_layer :]
@@ -148,7 +155,14 @@ class AppendOutput(Output):
                         Multiply.join(dimension_names)
                     )
                 )
-                return next_output, next_output.write_declarations(bucket), SourceBuilder()
+                # The bucket zero-init and accumulation are value work; the assemble kernel runs
+                # this subtree only to compute the gating flag structurally, so skip it there.
+                declarations = (
+                    next_output.write_declarations(bucket)
+                    if kernel_type.is_compute()
+                    else SourceBuilder()
+                )
+                return next_output, declarations, SourceBuilder()
             else:
                 raise NotImplementedError(
                     "Encountered a sparse output layer preceded by a contraction layer or a later "

--- a/src/tensora/iteration_graph/outputs/_base.py
+++ b/src/tensora/iteration_graph/outputs/_base.py
@@ -31,10 +31,11 @@ class Output:
             if mode == Mode.compressed
         ]
 
-    def has_active_flags(self) -> bool:
-        # A contraction or sum subtree must run structurally (even in the assemble kernel) when it
-        # gates a compressed output layer's flag. Since every compressed output layer sits above
-        # every contraction, this reduces to whether the output has any compressed layer at all.
+    def has_sparse_layer(self) -> bool:
+        # Whether the output has any compressed (sparse) layer. A contraction or sum subtree must
+        # run structurally (even in the assemble kernel) when it gates such a layer's written flag,
+        # and since every compressed output layer sits above every contraction, that need reduces
+        # to this property of the output.
         return any(mode == Mode.compressed for mode in self.output.modes)
 
     @abstractmethod

--- a/src/tensora/iteration_graph/outputs/_base.py
+++ b/src/tensora/iteration_graph/outputs/_base.py
@@ -8,7 +8,7 @@ from ...format import Mode
 from ...ir import SourceBuilder
 from ...ir.ast import Expression, Variable
 from ...kernel_type import KernelType
-from .._names import value_written_name
+from .._names import written_name
 from ..identifiable_expression import TensorLayer
 from ..identifiable_expression import ast as ie_ast
 
@@ -26,7 +26,7 @@ class Output:
         # so the set of flags to raise is recovered from the output format rather than threaded
         # down through the iteration.
         return [
-            value_written_name(self.output.id, layer)
+            written_name(self.output.name, layer)
             for layer, mode in enumerate(self.output.modes)
             if mode == Mode.compressed
         ]

--- a/src/tensora/iteration_graph/outputs/_base.py
+++ b/src/tensora/iteration_graph/outputs/_base.py
@@ -3,15 +3,27 @@ from __future__ import annotations
 __all__ = ["Output"]
 
 from abc import abstractmethod
+from dataclasses import replace
 
 from ...ir import SourceBuilder
-from ...ir.ast import Expression
+from ...ir.ast import Expression, Variable
 from ...kernel_type import KernelType
 from ..identifiable_expression import TensorLayer
 
 
 class Output:
     __slots__ = ()
+
+    # Subclasses store the tuple of "value written" flags gating the enclosing sparse output
+    # layers. A layer whose crd append is conditional on whether anything was written below it
+    # threads its flag down to the terminal, which sets it when a contribution branch executes.
+    gating_flags: tuple[Variable, ...]
+
+    def has_active_flags(self) -> bool:
+        return len(self.gating_flags) > 0
+
+    def with_flag(self, flag: Variable) -> Output:
+        return replace(self, gating_flags=(*self.gating_flags, flag))
 
     @abstractmethod
     def write_assignment(

--- a/src/tensora/iteration_graph/outputs/_base.py
+++ b/src/tensora/iteration_graph/outputs/_base.py
@@ -3,27 +3,39 @@ from __future__ import annotations
 __all__ = ["Output"]
 
 from abc import abstractmethod
-from dataclasses import replace
 
+from ...format import Mode
 from ...ir import SourceBuilder
 from ...ir.ast import Expression, Variable
 from ...kernel_type import KernelType
+from .._names import value_written_name
 from ..identifiable_expression import TensorLayer
+from ..identifiable_expression import ast as ie_ast
 
 
 class Output:
     __slots__ = ()
 
-    # Subclasses store the tuple of "value written" flags gating the enclosing sparse output
-    # layers. A layer whose crd append is conditional on whether anything was written below it
-    # threads its flag down to the terminal, which sets it when a contribution branch executes.
-    gating_flags: tuple[Variable, ...]
+    # Subclasses assemble this output tensor.
+    output: ie_ast.Tensor
+
+    def written_flags(self) -> list[Variable]:
+        # Each compressed output layer stores a coordinate only if a value is written below it. The
+        # terminal signals that by setting a per-layer "value written" flag. The flag name is a
+        # pure function of the layer, and every compressed output layer sits above every terminal,
+        # so the set of flags to raise is recovered from the output format rather than threaded
+        # down through the iteration.
+        return [
+            value_written_name(self.output.id, layer)
+            for layer, mode in enumerate(self.output.modes)
+            if mode == Mode.compressed
+        ]
 
     def has_active_flags(self) -> bool:
-        return len(self.gating_flags) > 0
-
-    def with_flag(self, flag: Variable) -> Output:
-        return replace(self, gating_flags=(*self.gating_flags, flag))
+        # A contraction or sum subtree must run structurally (even in the assemble kernel) when it
+        # gates a compressed output layer's flag. Since every compressed output layer sits above
+        # every contraction, this reduces to whether the output has any compressed layer at all.
+        return any(mode == Mode.compressed for mode in self.output.modes)
 
     @abstractmethod
     def write_assignment(

--- a/src/tensora/iteration_graph/outputs/_bucket.py
+++ b/src/tensora/iteration_graph/outputs/_bucket.py
@@ -17,12 +17,18 @@ class BucketOutput(Output):
     output: ie_ast.Tensor
     layers: list[int]
     unfulfilled: set[int]
+    gating_flags: tuple[Variable, ...]
 
     def __init__(
-        self, output: ie_ast.Tensor, layers: list[int], unfulfilled: set[int] | None = None
+        self,
+        output: ie_ast.Tensor,
+        layers: list[int],
+        unfulfilled: set[int] | None = None,
+        gating_flags: tuple[Variable, ...] = (),
     ):
         object.__setattr__(self, "output", output)
         object.__setattr__(self, "layers", layers)
+        object.__setattr__(self, "gating_flags", gating_flags)
         if unfulfilled is not None:
             object.__setattr__(self, "unfulfilled", unfulfilled)
         else:

--- a/src/tensora/iteration_graph/outputs/_bucket.py
+++ b/src/tensora/iteration_graph/outputs/_bucket.py
@@ -17,18 +17,12 @@ class BucketOutput(Output):
     output: ie_ast.Tensor
     layers: list[int]
     unfulfilled: set[int]
-    gating_flags: tuple[Variable, ...]
 
     def __init__(
-        self,
-        output: ie_ast.Tensor,
-        layers: list[int],
-        unfulfilled: set[int] | None = None,
-        gating_flags: tuple[Variable, ...] = (),
+        self, output: ie_ast.Tensor, layers: list[int], unfulfilled: set[int] | None = None
     ):
         object.__setattr__(self, "output", output)
         object.__setattr__(self, "layers", layers)
-        object.__setattr__(self, "gating_flags", gating_flags)
         if unfulfilled is not None:
             object.__setattr__(self, "unfulfilled", unfulfilled)
         else:

--- a/tests/codegen/test_ast_to_c.py
+++ b/tests/codegen/test_ast_to_c.py
@@ -77,6 +77,7 @@ single_lines = [
         "realloc(old, sizeof(double) * (previous + new))",
     ),
     # Declaration and types
+    (Declaration(Variable("x"), boolean), "bool x"),
     (Declaration(Variable("x"), integer), "int32_t x"),
     (Declaration(Variable("x"), float), "double x"),
     (Declaration(Variable("x"), tensor), "taco_tensor_t x"),
@@ -93,7 +94,6 @@ single_lines = [
     (Assignment(Variable("x"), Subtract(Variable("x"), IntegerLiteral(1))), "x--"),
     (Assignment(Variable("x"), Subtract(Variable("x"), IntegerLiteral(2))), "x -= 2"),
     (Assignment(Variable("x"), Multiply(Variable("x"), IntegerLiteral(2))), "x *= 2"),
-    (DeclarationAssignment(Declaration(Variable("x"), integer), Variable("y")), "int32_t x = y"),
     # Return
     (Return(IntegerLiteral(0)), "return 0"),
 ]

--- a/tests/codegen/test_ast_to_c.py
+++ b/tests/codegen/test_ast_to_c.py
@@ -19,8 +19,8 @@ single_lines = [
     (AttributeAccess(Variable("x"), "modes"), "x->modes"),
     (IntegerLiteral(2), "2"),
     (FloatLiteral(1.0), "1.0"),
-    (BooleanLiteral(False), "0"),
-    (BooleanLiteral(True), "1"),
+    (BooleanLiteral(False), "false"),
+    (BooleanLiteral(True), "true"),
     # Add
     (Add(Variable("x"), Variable("y")), "x + y"),
     (Add(Add(Variable("x"), Variable("y")), Variable("z")), "x + y + z"),

--- a/tests/ir/test_ast.py
+++ b/tests/ir/test_ast.py
@@ -1,0 +1,26 @@
+import pytest
+
+from tensora.ir.ast import (
+    BooleanLiteral,
+    FloatLiteral,
+    IntegerLiteral,
+    Variable,
+    to_expression,
+)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # bool must be checked before int because bool is a subclass of int
+        (True, BooleanLiteral(True)),
+        (False, BooleanLiteral(False)),
+        (1, IntegerLiteral(1)),
+        (0, IntegerLiteral(0)),
+        (1.5, FloatLiteral(1.5)),
+        ("x", Variable("x")),
+        (Variable("y"), Variable("y")),
+    ],
+)
+def test_to_expression(value, expected):
+    assert to_expression(value) == expected

--- a/tests/test_combinatorically.py
+++ b/tests/test_combinatorically.py
@@ -67,7 +67,7 @@ def test_vector_binary(operator, dense1, dense2, format1, format2, format_out):
 @pytest.mark.parametrize("dense2", [[[-1, 3.5], [0, 0], [4, 0]], [[0, 0], [0, 0], [0, 0]]])
 @pytest.mark.parametrize("format1", ["ss", "dd", "sd", "ds", "d1d0"])
 @pytest.mark.parametrize("format2", ["ss", "dd", "sd", "ds", "d1d0"])
-@pytest.mark.parametrize("format_out", ["dd", "d1d0"])
+@pytest.mark.parametrize("format_out", ["dd", "d1d0", "sd"])
 def test_matrix_dot(dense1, dense2, format1, format2, format_out):
     assert_same_as_dense(
         "out(i,k) = in1(i,j) * in2(j,k)", format_out, in1=(dense1, format1), in2=(dense2, format2)
@@ -91,7 +91,7 @@ def test_matrix_vector_product(dense1, dense2, format1, format2, format_out):
 @pytest.mark.parametrize("format1", ["dd", "ds"])
 @pytest.mark.parametrize("format2", ["dd"])
 @pytest.mark.parametrize("format3", ["dd", "ds"])
-@pytest.mark.parametrize("format_out", ["dd"])
+@pytest.mark.parametrize("format_out", ["dd", "d1d0", "ds", "sd", "ss"])
 def test_matrix_multiply_add(dense1, dense2, dense3, format1, format2, format3, format_out):
     assert_same_as_dense(
         "out(i,k) = in1(i,j) * in2(j,k) + in3(i,k)",
@@ -132,7 +132,7 @@ def test_matrix_multiply_add(dense1, dense2, dense3, format1, format2, format3, 
 @pytest.mark.parametrize("format_b", ["ddd", "dss", "sss", "ssd", "d1d0s2", "s0d2d1"])
 @pytest.mark.parametrize("format_d", ["dd", "ds", "ss"])
 @pytest.mark.parametrize("format_c", ["dd", "ds", "ss"])
-@pytest.mark.parametrize("format_out", ["dd", "d1d0"])
+@pytest.mark.parametrize("format_out", ["dd", "d1d0", "sd"])
 def test_mttkrp(dense_b, dense_d, dense_c, format_b, format_d, format_c, format_out):
     assert_same_as_dense(
         "A(i,j) = B(i,k,l) * D(l,j) * C(k,j)",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -119,11 +119,10 @@ def test_output_format_precludes_illegal_iteration_graphs():
     )
 
 
-def test_compressed_output_omits_explicit_zeros():
-    # This test exercises the case where a layer with a dense input and a sparse
-    # output is followed by a contractions. Here the contraction is often empty.
-    # The output is asserted to contain no explicit zeros from those empty
-    # contractions.
+def test_sparse_output_above_contraction_omits_explicit_zeros():
+    # This test exercises a dense output layer (i) sitting above a sparse output layer (j),
+    # which in turn sits above a contraction (k). Here the contraction is often empty.
+    # The output is asserted to contain no explicit zeros from those empty contractions.
     S = Tensor.from_lol([[1, 0, 2], [0, 0, 0]], dimensions=(2, 3), format="ds")
     rdx = Tensor.from_lol([[1, 0], [0, 4], [5, 0]], dimensions=(3, 2), format="d1s0")
 
@@ -131,6 +130,18 @@ def test_compressed_output_omits_explicit_zeros():
 
     actual = evaluate("J(i,j) = S(i,r) * rdx(r,j)", "ds", S=S, rdx=rdx)
 
-    assert actual.to_dok() == expected
-    # The stored structure must contain no explicit zeros beyond the true nonzero.
+    assert actual.to_dok(explicit_zeros=True) == expected
+
+
+def test_sparse_output_above_dense_above_contraction_omits_explicit_zeros():
+    # This test exercises a sparse output layer (i) sitting above a dense output layer (j),
+    # which in turn sits above a contraction (k). Here the contraction is often empty.
+    # The output is asserted to contain no explicit zeros from those empty contractions.
+    B = Tensor.from_lol([[1, 0, 2], [0, 0, 0]], dimensions=(2, 3), format="ds")
+    C = Tensor.from_lol([[1, 2], [0, 0], [3, 4]], dimensions=(3, 2), format="dd")
+
+    expected = {(0, 0): 7.0, (0, 1): 10.0}
+
+    actual = evaluate("A(i,j) = B(i,k) * C(k,j)", "sd", B=B, C=C)
+
     assert actual.to_dok(explicit_zeros=True) == expected

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -120,10 +120,10 @@ def test_output_format_precludes_illegal_iteration_graphs():
 
 
 def test_compressed_output_omits_explicit_zeros():
-    # A contraction into a densely-iterated compressed output must not store an
-    # explicit zero at coordinates where the contraction is empty. Here S has an
-    # empty second row and rdx has a dense j mode, so a naive kernel would append
-    # J(0,1), J(1,0), and J(1,1) as explicit zeros. Only J(0,0) is a true nonzero.
+    # This test exercises the case where a layer with a dense input and a sparse
+    # output is followed by a contractions. Here the contraction is often empty.
+    # The output is asserted to contain no explicit zeros from those empty
+    # contractions.
     S = Tensor.from_lol([[1, 0, 2], [0, 0, 0]], dimensions=(2, 3), format="ds")
     rdx = Tensor.from_lol([[1, 0], [0, 4], [5, 0]], dimensions=(3, 2), format="d1s0")
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -117,3 +117,20 @@ def test_output_format_precludes_illegal_iteration_graphs():
         rdu=([[0, 2], [1, 0], [0, 3]], "ds"),
         udx=([[1, 0], [0, 6]], "d1s0"),
     )
+
+
+def test_compressed_output_omits_explicit_zeros():
+    # A contraction into a densely-iterated compressed output must not store an
+    # explicit zero at coordinates where the contraction is empty. Here S has an
+    # empty second row and rdx has a dense j mode, so a naive kernel would append
+    # J(0,1), J(1,0), and J(1,1) as explicit zeros. Only J(0,0) is a true nonzero.
+    S = Tensor.from_lol([[1, 0, 2], [0, 0, 0]], dimensions=(2, 3), format="ds")
+    rdx = Tensor.from_lol([[1, 0], [0, 4], [5, 0]], dimensions=(3, 2), format="d1s0")
+
+    expected = {(0, 0): 11.0}
+
+    actual = evaluate("J(i,j) = S(i,r) * rdx(r,j)", "ds", S=S, rdx=rdx)
+
+    assert actual.to_dok() == expected
+    # The stored structure must contain no explicit zeros beyond the true nonzero.
+    assert actual.to_dok(explicit_zeros=True) == expected

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -121,7 +121,7 @@ def test_output_format_precludes_illegal_iteration_graphs():
 
 def test_sparse_output_above_contraction_omits_explicit_zeros():
     # This test exercises a dense output layer (i) sitting above a sparse output layer (j),
-    # which in turn sits above a contraction (k). Here the contraction is often empty.
+    # which in turn sits above a contraction (r). Here the contraction is often empty.
     # The output is asserted to contain no explicit zeros from those empty contractions.
     S = Tensor.from_lol([[1, 0, 2], [0, 0, 0]], dimensions=(2, 3), format="ds")
     rdx = Tensor.from_lol([[1, 0], [0, 4], [5, 0]], dimensions=(3, 2), format="d1s0")


### PR DESCRIPTION
We currently determine that a sparse output layer needs to write a value using two rules:
1. If this is dense iteration, then write an explicit zero.
    - This is very problematic because this results in a large number of unnecessary explicit zeros when this layer is on top of a sparse input layer, such as a contraction, which could be empty and should be stored as an implicit zero.
2. If the next layer is sparse, write a value if and only if that lower layer wrote a value.
    - This is not wrong, and is fine.
3. If the next layer is dense, write a value because a dense layer has to write a value.
    - This is wildly wrong for the same reason as (1). A sparse layer even lower down could be empty.

This PR changes the heuristic entirely. A sparse layer writes a value at the end of an iteration if and only if a terminal expression wrote a value during that iteration. This is tracked by having a `written_*` flag for each sparse output layer. This flag is set to false at the start of each iteration corresponding to that layer, and all flags are set to true every time a value is written.

This replaces the previous mechanism of a sparse layer looking at the layer below it to see if it advanced. We might be leaving a bit of performance on the table by setting all the flags every time. We could probably be a little more efficient if we only set the upper layer's flag when we handled a lower layer's flag rather than setting it on every terminal evaluation.

There is also one more interesting fact. A terminal expression that writes a literal `0` does not set the flag. A sparse layer above a dense layer should not write a value if only zeros were written to the dense layer. There may be some performance gains to be had here also, but these kernels are pretty rare, so they will probably not be a priority for a while.